### PR TITLE
Improve error handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,29 @@ class ErrorResponse(BaseModel):
     message: str
 
 # -------------------------------
+# Exception Handling
+# -------------------------------
+
+ERROR_CODE_MAP = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    404: "NOT_FOUND",
+    429: "LIMIT_EXCEEDED",
+    502: "GPT_TIMEOUT",
+}
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    """Return errors using ErrorResponse schema."""
+    error_code = ERROR_CODE_MAP.get(exc.status_code, "BAD_REQUEST")
+    message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"code": error_code, "message": message},
+    )
+
+# -------------------------------
 # Middleware / Dependency
 # -------------------------------
 
@@ -37,7 +60,7 @@ async def verify_headers(
         raise HTTPException(status_code=400, detail="Invalid API version")
     # Здесь можно добавить валидацию ключа
     if x_api_key != "test-api-key":
-        raise HTTPException(status_code=401, detail="UNAUTHORIZED")
+        raise HTTPException(status_code=401, detail="Invalid API key")
 
 # -------------------------------
 # Diagnose Endpoint
@@ -64,7 +87,7 @@ async def diagnose(
     if image:
         contents = await image.read()
         if len(contents) > 2 * 1024 * 1024:
-            raise HTTPException(status_code=400, detail="BAD_REQUEST: image too large")
+            raise HTTPException(status_code=400, detail="Image too large")
         # заглушка: обрабатываем изображение
         return DiagnoseResponse(crop="apple", disease="powdery_mildew", confidence=0.92)
     else:
@@ -72,6 +95,6 @@ async def diagnose(
             json_data = await request.json()
             body = DiagnoseRequestBase64(**json_data)
         except Exception:
-            raise HTTPException(status_code=400, detail="BAD_REQUEST: invalid JSON")
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
         # заглушка: обработка base64
         return DiagnoseResponse(crop="apple", disease="scab", confidence=0.88)


### PR DESCRIPTION
## Summary
- standardize HTTP exceptions to match `ErrorResponse`
- use a global handler for FastAPI `HTTPException`
- improve error messages in `verify_headers`

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e13e58eb8832a8e6710d9e10832a8