### PR TITLE
Enforce prompt_id validation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI, Header, UploadFile, File, Request, HTTPException
+from fastapi import FastAPI, Header, UploadFile, File, Request, HTTPException, Form
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, ValidationError
 from typing import Optional
 
 app = FastAPI(
@@ -15,6 +15,13 @@ app = FastAPI(
 class DiagnoseRequestBase64(BaseModel):
     image_base64: str
     prompt_id: str
+
+    @field_validator("prompt_id")
+    @classmethod
+    def validate_prompt_id(cls, v: str) -> str:
+        if v != "v1":
+            raise ValueError("prompt_id must be 'v1'")
+        return v
 
 class DiagnoseResponse(BaseModel):
     crop: str
@@ -56,22 +63,32 @@ async def diagnose(
     request: Request,
     x_api_key: str = Header(..., alias="X-API-Key"),
     x_api_ver: str = Header(..., alias="X-API-Ver"),
-    image: Optional[UploadFile] = File(None)
+    image: Optional[UploadFile] = File(None),
+    prompt_id: Optional[str] = Form(None)
 ):
     await verify_headers(x_api_key, x_api_ver)
 
     # Определяем формат (multipart vs json)
     if image:
+        if prompt_id != "v1":
+            err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
+            return JSONResponse(status_code=400, content=err.model_dump())
         contents = await image.read()
         if len(contents) > 2 * 1024 * 1024:
-            raise HTTPException(status_code=400, detail="BAD_REQUEST: image too large")
+            err = ErrorResponse(code="BAD_REQUEST", message="image too large")
+            return JSONResponse(status_code=400, content=err.model_dump())
         # заглушка: обрабатываем изображение
         return DiagnoseResponse(crop="apple", disease="powdery_mildew", confidence=0.92)
     else:
         try:
             json_data = await request.json()
-            body = DiagnoseRequestBase64(**json_data)
         except Exception:
-            raise HTTPException(status_code=400, detail="BAD_REQUEST: invalid JSON")
+            err = ErrorResponse(code="BAD_REQUEST", message="invalid JSON")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        try:
+            body = DiagnoseRequestBase64(**json_data)
+        except ValidationError:
+            err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
+            return JSONResponse(status_code=400, content=err.model_dump())
         # заглушка: обработка base64
         return DiagnoseResponse(crop="apple", disease="scab", confidence=0.88)


### PR DESCRIPTION
## Summary
- validate `prompt_id` in `DiagnoseRequestBase64`
- parse and enforce `prompt_id` for multipart requests
- use standardized `ErrorResponse` when rejecting invalid values

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1698ecbc832aa71ac80f9ca98028