### PR TITLE
Implement quotas and initial schema

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,8 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,10 @@ from fastapi import FastAPI, Header, UploadFile, File, Request, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
+from datetime import datetime
+
+from app.db import SessionLocal
+from app.models import Photo, PhotoQuota
 
 app = FastAPI(
     title="Agronom Bot Internal API",
@@ -24,6 +28,10 @@ class DiagnoseResponse(BaseModel):
 class ErrorResponse(BaseModel):
     code: str
     message: str
+
+class LimitsResponse(BaseModel):
+    limit_monthly_free: int
+    used_this_month: int
 
 # -------------------------------
 # Middleware / Dependency
@@ -60,18 +68,75 @@ async def diagnose(
 ):
     await verify_headers(x_api_key, x_api_ver)
 
+    user_id = 1  # в MVP ключ привязан к одному пользователю
+
+    db = SessionLocal()
+    month = datetime.utcnow().strftime("%Y-%m")
+    quota = db.query(PhotoQuota).filter_by(user_id=user_id, month_year=month).first()
+    if not quota:
+        quota = PhotoQuota(user_id=user_id, used_count=0, month_year=month)
+        db.add(quota)
+        db.commit()
+        db.refresh(quota)
+
+    if quota.used_count >= 5:
+        db.close()
+        raise HTTPException(status_code=429, detail="LIMIT_EXCEEDED")
+
     # Определяем формат (multipart vs json)
     if image:
         contents = await image.read()
         if len(contents) > 2 * 1024 * 1024:
+            db.close()
             raise HTTPException(status_code=400, detail="BAD_REQUEST: image too large")
         # заглушка: обрабатываем изображение
-        return DiagnoseResponse(crop="apple", disease="powdery_mildew", confidence=0.92)
+        crop, disease, conf = "apple", "powdery_mildew", 0.92
     else:
         try:
             json_data = await request.json()
             body = DiagnoseRequestBase64(**json_data)
         except Exception:
+            db.close()
             raise HTTPException(status_code=400, detail="BAD_REQUEST: invalid JSON")
-        # заглушка: обработка base64
-        return DiagnoseResponse(crop="apple", disease="scab", confidence=0.88)
+        crop, disease, conf = "apple", "scab", 0.88
+
+    photo = Photo(
+        user_id=user_id,
+        file_id="placeholder",
+        crop=crop,
+        disease=disease,
+        confidence=conf,
+        status="ok",
+        ts=datetime.utcnow(),
+        deleted=False,
+    )
+    db.add(photo)
+    quota.used_count += 1
+    db.commit()
+    db.refresh(photo)
+    db.close()
+
+    return DiagnoseResponse(crop=crop, disease=disease, confidence=conf)
+
+
+@app.get(
+    "/v1/limits",
+    response_model=LimitsResponse,
+    responses={
+        401: {"model": ErrorResponse}
+    }
+)
+async def get_limits(
+    x_api_key: str = Header(..., alias="X-API-Key"),
+    x_api_ver: str = Header(..., alias="X-API-Ver"),
+):
+    await verify_headers(x_api_key, x_api_ver)
+
+    user_id = 1
+    db = SessionLocal()
+    month = datetime.utcnow().strftime("%Y-%m")
+    quota = db.query(PhotoQuota).filter_by(user_id=user_id, month_year=month).first()
+    used = quota.used_count if quota else 0
+    db.close()
+    return LimitsResponse(limit_monthly_free=5, used_this_month=used)
+

--- a/migrations/versions/b41be693ec24_init_schema.py
+++ b/migrations/versions/b41be693ec24_init_schema.py
@@ -7,6 +7,7 @@ Create Date: 2025-07-20 21:56:49.376862
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 
 
@@ -17,7 +18,88 @@ branch_labels = None
 depends_on = None
 
 def upgrade() -> None:
-    pass
+    # Enums
+    payment_status = postgresql.ENUM('success', 'fail', 'cancel', 'bank_error', name='payment_status')
+    photo_status = postgresql.ENUM('pending', 'ok', 'retrying', name='photo_status')
+    order_status = postgresql.ENUM('new', 'processed', 'cancelled', name='order_status')
+    error_code = postgresql.ENUM('NO_LEAF', 'LIMIT_EXCEEDED', 'GPT_TIMEOUT', 'BAD_REQUEST', 'UNAUTHORIZED', name='error_code')
+
+    payment_status.create(op.get_bind(), checkfirst=True)
+    photo_status.create(op.get_bind(), checkfirst=True)
+    order_status.create(op.get_bind(), checkfirst=True)
+    error_code.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('tg_id', sa.BigInteger, nullable=False),
+        sa.Column('pro_expires_at', sa.DateTime),
+        sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        'photos',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, nullable=False),
+        sa.Column('file_id', sa.Text, nullable=False),
+        sa.Column('crop', sa.Text),
+        sa.Column('disease', sa.Text),
+        sa.Column('confidence', sa.Numeric),
+        sa.Column('status', sa.Enum('pending', 'ok', 'retrying', name='photo_status'), nullable=False, server_default='pending'),
+        sa.Column('ts', sa.DateTime, server_default=sa.func.now()),
+        sa.Column('deleted', sa.Boolean, server_default='false'),
+    )
+
+    op.create_table(
+        'protocols',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('crop', sa.Text),
+        sa.Column('disease', sa.Text),
+        sa.Column('product', sa.Text),
+        sa.Column('dosage_value', sa.Numeric),
+        sa.Column('dosage_unit', sa.Text),
+        sa.Column('phi', sa.Integer),
+    )
+
+    op.create_table(
+        'payments',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, nullable=False),
+        sa.Column('amount', sa.Integer),
+        sa.Column('source', sa.Text),
+        sa.Column('status', sa.Enum('success', 'fail', 'cancel', 'bank_error', name='payment_status'), nullable=False),
+        sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        'partner_orders',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, nullable=False),
+        sa.Column('order_id', sa.Text),
+        sa.Column('protocol_id', sa.Integer),
+        sa.Column('price_kopeks', sa.Integer),
+        sa.Column('signature', sa.Text),
+        sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+        sa.Column('status', sa.Enum('new', 'processed', 'cancelled', name='order_status'), nullable=False, server_default='new'),
+    )
+
+    op.create_table(
+        'photo_quota',
+        sa.Column('user_id', sa.Integer, primary_key=True),
+        sa.Column('used_count', sa.Integer),
+        sa.Column('month_year', sa.String(length=7)),
+    )
 
 def downgrade() -> None:
-    pass
+    op.drop_table('photo_quota')
+    op.drop_table('partner_orders')
+    op.drop_table('payments')
+    op.drop_table('protocols')
+    op.drop_table('photos')
+    op.drop_table('users')
+
+    op.execute('DROP TYPE IF EXISTS error_code')
+    op.execute('DROP TYPE IF EXISTS order_status')
+    op.execute('DROP TYPE IF EXISTS photo_status')
+    op.execute('DROP TYPE IF EXISTS payment_status')
+


### PR DESCRIPTION
## Summary
- create `app.db` database connection helper
- implement photo quota checks and `/v1/limits` endpoint
- fill out Alembic migration to create tables for the MVP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e169baa8c832a8d927c2acd67f0d1