### PR TITLE
Remove unused verify_hmac helper

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -94,12 +94,6 @@ async def verify_version(x_api_ver: str = Header(..., alias="X-API-Ver")):
     if x_api_ver != "v1":
         raise HTTPException(status_code=400, detail="Invalid API version")
 
-def verify_hmac(body: bytes, provided: str) -> str:
-    expected = hmac.new(HMAC_SECRET.encode(), body, hashlib.sha256).hexdigest()
-    if not hmac.compare_digest(expected, provided):
-        raise HTTPException(status_code=401, detail="UNAUTHORIZED")
-    return expected
-
 def compute_signature(secret: str, body: bytes) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 


### PR DESCRIPTION
## Summary
- remove obsolete synchronous `verify_hmac` helper
- keep async `verify_hmac` implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687e365c3c4c832a84f9fd2cdaa3fce8