### PR TITLE
Update HMAC verification logic

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,10 +105,11 @@ def test_payment_webhook_success():
         "currency": "RUB",
         "status": "success",
     }
-    payload["signature"] = compute_signature("test-hmac-secret", json.dumps(payload).encode())
+    sig = compute_signature("test-hmac-secret", json.dumps(payload).encode())
+    payload["signature"] = sig
     headers = {
         "X-API-Ver": "v1",
-        "X-Sign": compute_signature("test-hmac-secret", json.dumps(payload).encode()),
+        "X-Sign": sig,
     }
     resp = client.post(
         "/v1/payments/sbp/webhook",
@@ -158,12 +159,13 @@ def test_partner_order_success():
         "protocol_id": 2,
         "price_kopeks": 100,
     }
-    payload["signature"] = compute_signature("test-hmac-secret", json.dumps(payload).encode())
+    sig = compute_signature("test-hmac-secret", json.dumps(payload).encode())
+    payload["signature"] = sig
     resp = client.post(
         "/v1/partner/orders",
         headers={
             "X-API-Ver": "v1",
-            "X-Sign": compute_signature("test-hmac-secret", json.dumps(payload).encode()),
+            "X-Sign": sig,
         },
         json=payload,
     )


### PR DESCRIPTION
## Summary
- compute request signatures without the `signature` field
- validate `signature` from the body against the recalculated value
- adjust tests to send properly signed payloads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687e37597d4c832ab6df9b4c216c81fe