### PR TITLE
Align models with DB enums

### DIFF
--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, Enum
 from app.models.base import Base
 from datetime import datetime
 
@@ -9,5 +9,8 @@ class Payment(Base):
     user_id = Column(Integer, nullable=False)
     amount = Column(Integer)
     source = Column(String)
-    status = Column(String)
+    status = Column(
+        Enum("success", "fail", "cancel", "bank_error", name="payment_status"),
+        nullable=False,
+    )
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/models/photo.py
+++ b/app/models/photo.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, Enum
 from app.models.base import Base
 from datetime import datetime
 
@@ -11,6 +11,10 @@ class Photo(Base):
     crop = Column(String)
     disease = Column(String)
     confidence = Column(Float)
-    status = Column(String)
+    status = Column(
+        Enum("pending", "ok", "retrying", name="photo_status"),
+        nullable=False,
+        server_default="pending",
+    )
     ts = Column(DateTime, default=datetime.utcnow)
     deleted = Column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- use PostgreSQL enums in `Photo` and `Payment` models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687e386ec798832aae90f9e14883cb51