### PR TITLE
Remove /protocol endpoint references

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -7,9 +7,9 @@ MVP = Telegram‑bot.Launch ≤ 2 weeks.Handle ≤ 50 000 MAU without r
 2 · Stack Overview
 (см. C4) Node.js, GPT-Vision API, PostgreSQL, Redis, S3-compatible storage, Vault, k8s, Prometheus, Loki, Grafana.
 3 · C4 Diagrams (text)
-C1 System: Farmer → Telegram Bot ↔ Telegram API → App Svc → GPT‑Vision / PostgreSQL / S3 → Prometheus.C2 Containers: Bot Gateway, App Service, Worker, PG 14, S3 (VK), Prom+Grafana+Loki+Tempo.C3 App Components: DiagnoseController, ProtocolController, PaymentController, LimitsController.C4 Worker: BullQueue → RetryJobHandler (fetch photo → GPT → update DB).
+C1 System: Farmer → Telegram Bot ↔ Telegram API → App Svc → GPT‑Vision / PostgreSQL / S3 → Prometheus.C2 Containers: Bot Gateway, App Service, Worker, PG 14, S3 (VK), Prom+Grafana+Loki+Tempo.C3 App Components: DiagnoseController, PaymentController, LimitsController.C4 Worker: BullQueue → RetryJobHandler (fetch photo → GPT → update DB).
 4 · Data Flow
-Photo → Bot → App /v1/ai/diagnose → store JPEG in S3 + row in photos (status=pending) → GPT → update status=ok → Bot./protocol → App → protocols table → Bot./limits → App → counts photo rows for current month./partner/orders → HMAC check (header+body) → insert order.Webhook: /v1/payments/sbp/webhook → update user → Bot.
+Photo → Bot → App /v1/ai/diagnose → store JPEG in S3 + row in photos (status=pending) → GPT → update status=ok → Bot./limits → App → counts photo rows for current month./partner/orders → HMAC check (header+body) → insert order.Webhook: /v1/payments/sbp/webhook → update user → Bot.
 5 · Service-Level Objectives (SLO)
 diag_latency_p95 < 8s; GPT_timeout_ratio < 1%; uptime ≥ 99.5%; 0 critical quota leaks.
 6 · Scaling Plan

--- a/docs/srs.md
+++ b/docs/srs.md
@@ -33,7 +33,7 @@ FR‑T‑02
 Diagnose — POST /v1/ai/diagnose, возвращает диагноз.
 High
 FR‑T‑03
-Show Protocol — /protocol или кнопка после диагноза.
+Show Protocol — кнопка после диагноза.
 High
 FR‑T‑04
 Purchase Pro — платёж через Bot Payments (СБП).
@@ -89,7 +89,7 @@ Bot → TG: getFile
 Bot → GPT: diagnose
 GPT → Bot: JSON
 Bot → DB: insert photo
-Bot → User: message diagnosis + /protocol
+Bot → User: message diagnosis + кнопка «Протокол»
 6.2 Purchase Pro
 User → Bot: click Pay
 Bot → TG Payments: invoice


### PR DESCRIPTION
## Summary
- cleanup docs mentioning the unimplemented `/protocol` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687e3be56d94832aa8a849789e886285