### PR TITLE
Allow diagnose without prompt_id in multipart

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -159,7 +159,7 @@ async def diagnose(
 
     # Определяем формат (multipart vs json)
     if image:
-        if prompt_id != "v1":
+        if prompt_id not in (None, "v1"):
             err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
             db.close()
             return JSONResponse(status_code=400, content=err.model_dump())


### PR DESCRIPTION
## Summary
- relax `prompt_id` validation in the multipart diagnose branch

## Testing
- `pytest -q tests/test_api.py::test_diagnose_multipart_success` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687e3ff598f4832aa53d675d0ac1ac57