### PR TITLE
Add httpx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ starlette==0.44.0
 typing_extensions==4.13.2
 uvicorn==0.33.0
 zipp==3.20.2
+
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- add `httpx` to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687e41a4be7c832aa27fd14026e3ea8f