### PR TITLE
feat: add GPT Vision stub

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ import hmac
 import hashlib
 
 from app.services.storage import upload_photo
+from app.services.gpt import call_gpt_vision_stub
 
 from app.db import SessionLocal
 from app.models import Photo, PhotoQuota, Payment, PartnerOrder
@@ -173,8 +174,11 @@ async def diagnose(
             return JSONResponse(status_code=400, content=err.model_dump())
         key = upload_photo(user_id, contents)
 
-        # заглушка: обрабатываем изображение
-        crop, disease, conf = "apple", "powdery_mildew", 0.92
+        # заглушка GPT-Vision
+        result = call_gpt_vision_stub(key)
+        crop = result.get("crop", "")
+        disease = result.get("disease", "")
+        conf = result.get("confidence", 0.0)
         file_id = key
     else:
         try:
@@ -191,7 +195,10 @@ async def diagnose(
             return JSONResponse(status_code=400, content=err.model_dump())
         contents = base64.b64decode(body.image_base64)
         key = upload_photo(user_id, contents)
-        crop, disease, conf = "apple", "powdery_mildew", 0.92
+        result = call_gpt_vision_stub(key)
+        crop = result.get("crop", "")
+        disease = result.get("disease", "")
+        conf = result.get("confidence", 0.0)
         file_id = key
 
     photo = Photo(

--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -1,0 +1,23 @@
+"""GPT-Vision integration stubs."""
+
+from __future__ import annotations
+
+
+def call_gpt_vision_stub(image_path: str) -> dict:
+    """Return mock diagnosis for the given image.
+
+    Parameters
+    ----------
+    image_path: str
+        Path to the uploaded image. Only used for debugging
+        in this stub implementation.
+
+    Returns
+    -------
+    dict
+        Mocked GPT response with keys: ``crop``, ``disease`` and ``confidence``.
+    """
+    # In real integration this function would upload the image to GPT-Vision
+    # and parse the JSON response. The stub always returns a fixed payload.
+    return {"crop": "apple", "disease": "powdery_mildew", "confidence": 0.92}
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-import io
 import json
 from fastapi.testclient import TestClient
 from app.main import app, compute_signature

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -1,0 +1,11 @@
+from app.services.gpt import call_gpt_vision_stub
+
+
+def test_gpt_stub_returns_mock():
+    resp = call_gpt_vision_stub("photo.jpg")
+    assert isinstance(resp, dict)
+    assert resp == {
+        "crop": "apple",
+        "disease": "powdery_mildew",
+        "confidence": 0.92,
+    }


### PR DESCRIPTION
## Summary
- create GPT stub service returning mock diagnosis
- use stub in diagnose endpoint
- add simple tests for GPT stub
- fix linting in tests

## Testing
- `ruff check app/ tests/`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi and boto3)*

------
https://chatgpt.com/codex/tasks/task_e_687e84b13824832abdeb8dbdf3e2409c