### PR TITLE
[test] cover telegraf handler and diagnose endpoint

### DIFF
--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -1,0 +1,25 @@
+async function photoHandler(pool, ctx) {
+  const photo = ctx.message.photo[ctx.message.photo.length - 1];
+  const { file_id, file_unique_id, width, height, file_size } = photo;
+  const userId = ctx.from.id;
+  try {
+    await pool.query(
+      `INSERT INTO photos (user_id, file_id, file_unique_id, width, height, file_size, status)
+       VALUES ($1, $2, $3, $4, $5, $6, 'pending')`,
+      [userId, file_id, file_unique_id, width, height, file_size]
+    );
+  } catch (err) {
+    console.error('DB insert error', err);
+  }
+  if (typeof ctx.reply === 'function') {
+    await ctx.reply('Фото получено');
+  }
+}
+
+function messageHandler(ctx) {
+  if (!ctx.message.photo) {
+    console.log('Ignoring non-photo message');
+  }
+}
+
+module.exports = { photoHandler, messageHandler };

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -1,0 +1,26 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { photoHandler, messageHandler } = require('./handlers');
+
+test('photoHandler stores info and replies', async () => {
+  const calls = [];
+  const pool = { query: async (...args) => { calls.push(args); } };
+  const replies = [];
+  const ctx = {
+    message: { photo: [{ file_id: 'id1', file_unique_id: 'uid', width: 1, height: 2, file_size: 3 }] },
+    from: { id: 42 },
+    reply: async (msg) => replies.push(msg),
+  };
+  await photoHandler(pool, ctx);
+  assert.equal(calls.length, 1);
+  assert.equal(replies[0], 'Фото получено');
+});
+
+test('messageHandler ignores non-photo', () => {
+  let logged = '';
+  const orig = console.log;
+  console.log = (msg) => { logged = msg; };
+  messageHandler({ message: { text: 'hi' } });
+  console.log = orig;
+  assert.equal(logged, 'Ignoring non-photo message');
+});

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
+const { photoHandler, messageHandler } = require('./handlers');
 
 const token = process.env.BOT_TOKEN_DEV;
 if (!token) {
@@ -10,27 +11,8 @@ if (!token) {
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const bot = new Telegraf(token);
 
-bot.on('photo', async (ctx) => {
-  const photo = ctx.message.photo[ctx.message.photo.length - 1];
-  const { file_id, file_unique_id, width, height, file_size } = photo;
-  const userId = ctx.from.id;
-  console.log('Received photo', file_id);
-  try {
-    await pool.query(
-      `INSERT INTO photos (user_id, file_id, file_unique_id, width, height, file_size, status)
-       VALUES ($1, $2, $3, $4, $5, $6, 'pending')`,
-      [userId, file_id, file_unique_id, width, height, file_size]
-    );
-  } catch (err) {
-    console.error('DB insert error', err);
-  }
-  await ctx.reply('Фото получено');
-});
+bot.on('photo', (ctx) => photoHandler(pool, ctx));
 
-bot.on('message', (ctx) => {
-  if (!ctx.message.photo) {
-    console.log('Ignoring non-photo message');
-  }
-});
+bot.on('message', messageHandler);
 
 bot.launch().then(() => console.log('Bot started'));

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,6 +69,47 @@ def test_diagnose_large_image():
     assert resp.status_code == 400
 
 
+def test_diagnose_json_returns_stub():
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "crop": "apple",
+        "disease": "powdery_mildew",
+        "confidence": 0.92,
+    }
+
+
+def test_diagnose_json_bad_prompt():
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": "dGVzdA==", "prompt_id": "v2"},
+    )
+    assert resp.status_code == 400
+
+
+def test_diagnose_json_missing_prompt():
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": "dGVzdA=="},
+    )
+    assert resp.status_code == 400
+
+
+def test_diagnose_multipart_missing_image():
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        files={"file": ("x.txt", b"123", "text/plain")},
+    )
+    assert resp.status_code == 400
+
+
 def test_quota_exceeded():
     limits = client.get("/v1/limits", headers=HEADERS)
     assert limits.status_code == 200


### PR DESCRIPTION
## Summary
- export telegraf handlers for testing
- add node tests for handlers
- add API diagnose edge case tests

## Testing
- `ruff check app/`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/boto3)*
- `node --test bot/handlers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687e86111b58832ab1eedb04c79d61a3