### PR TITLE
[docs] update local setup docs and API spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,16 @@ uvicorn app.main:app --reload
 # Запуск тестов
 pytest
 
+# Запуск Telegram‑бота
+npm install --prefix bot
+node bot/index.js
+
 # Линтинг
 flake8 app/
 # или
 ruff app/
 🔑 Переменные окружения
-Смотри файл .env.template для примера.
+Скопируйте `.env.template` в `.env` и укажите настройки.
 
 Не коммитьте реальные токены!
 
@@ -35,9 +39,9 @@ ruff app/
 
 Минимально необходимые переменные:
 
+POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, POSTGRES_HOST, POSTGRES_PORT
 DATABASE_URL — строка подключения к БД
-
-S3_* — настройки S3/Minio
+S3_BUCKET, S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY
 
 BOT_TOKEN_DEV — Telegram Bot Token (тестовый!)
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,49 @@ agronom-bot/
 
 
 
-## 🛠️ Установка (локально)
+## 🛠️ Установка и запуск локально
 
+1. Скопируйте `.env.template` в `.env` и укажите параметры подключения к БД и S3. Минимально нужны:
 
-pip install -r requirements.txt
-alembic upgrade head
-uvicorn app.main:app --reload
-npm install --prefix bot
-node bot/index.js
+   ```env
+   POSTGRES_USER=postgres
+   POSTGRES_PASSWORD=postgres
+   POSTGRES_DB=agronom
+   POSTGRES_HOST=localhost
+   POSTGRES_PORT=5432
+   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
+
+   S3_BUCKET=agronom
+   S3_ENDPOINT=http://localhost:9000
+   S3_ACCESS_KEY=minio
+   S3_SECRET_KEY=minio123
+   ```
+
+2. Установите зависимости и примените миграции:
+
+   ```bash
+   pip install -r requirements.txt
+   alembic upgrade head
+   ```
+
+3. Запустите API:
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+4. Запустите Telegram‑бота:
+
+   ```bash
+   npm install --prefix bot
+   node bot/index.js
+   ```
+
+5. Тесты запускаются командой:
+
+   ```bash
+   pytest
+   ```
 📖 Документация
 Смотри в папке docs/:
 

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -26,6 +26,11 @@ CREATE TYPE payment_status AS ENUM ('success','fail','cancel','bank_error');CREA
 graph TDPENDING[photos.status=pending] -->|predict| OK[status=ok]PENDING -->|retry| RETRY[status=retrying]RETRY -->|predict| OKPhotos auto-delete from S3 after 90d. DB rows soft-deleted 30d later. Quota resets monthly.
 6 · API ↔ DB Mapping (extract)
 /v1/ai/diagnose → insert photos/v1/limits → read photo_quota + count from photos/v1/payments/sbp/webhook → insert payments/v1/partner/orders → insert partner_orders (with signature)
+
+6.1 · /v1/ai/diagnose
+Принимает фото в multipart (`image`) или JSON (`image_base64`). Возвращает
+`{crop, disease, confidence}` и создаёт запись в `photos`, увеличивая счётчик
+`photo_quota.used_count`.
 7 · Ownership & Lineage
 Airflow DAG: export_daily_metrics → S3 → Metabase. См. Data_Lineage.xlsx.
 8 · Privacy & Compliance

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -157,6 +157,10 @@ paths:
   /v1/ai/diagnose:
     post:
       summary: Diagnose plant disease
+      description: |
+        Upload a leaf photo and get back the predicted crop,
+        disease and confidence score. Supports multipart uploads
+        via `image` field or JSON body with `image_base64`.
       security:
         - ApiKeyAuth: []
       parameters:


### PR DESCRIPTION
## Summary
- expand README with steps for running the API and Telegram bot locally
- clarify env variables and test commands in AGENTS guide
- document /v1/ai/diagnose behavior in data_contract
- add endpoint description to OpenAPI

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for `fastapi` and `boto3`)*
- `spectral lint openapi/openapi.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8879251c832aa1a276bcf3d1cfc2