### PR TITLE
[feature] add telegram bot handlers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,11 @@ HTTPS_PROXY=http://user:pass@host:port
 # Токен Telegram-бота для разработки (BotFather)
 BOT_TOKEN_DEV=your-dev-telegram-bot-token-here
 
+# Настройки доступа бота к внутреннему API
+API_BASE_URL=http://localhost:8000
+API_KEY=test-api-key
+API_VER=v1
+
 # Токен Telegram-бота для продакшена (BotFather)
 # BOT_TOKEN_PROD=your-prod-telegram-bot-token-here
 

--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -1,3 +1,7 @@
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8000';
+const API_KEY = process.env.API_KEY || 'test-api-key';
+const API_VER = process.env.API_VER || 'v1';
+
 async function photoHandler(pool, ctx) {
   const photo = ctx.message.photo[ctx.message.photo.length - 1];
   const { file_id, file_unique_id, width, height, file_size } = photo;
@@ -11,8 +15,38 @@ async function photoHandler(pool, ctx) {
   } catch (err) {
     console.error('DB insert error', err);
   }
-  if (typeof ctx.reply === 'function') {
-    await ctx.reply('Фото получено');
+
+  try {
+    const link = await ctx.telegram.getFileLink(file_id);
+    console.log('Downloading photo from', link.href);
+    const res = await fetch(link.href);
+    const buffer = Buffer.from(await res.arrayBuffer());
+    const form = new FormData();
+    form.append('image', new Blob([buffer], { type: 'image/jpeg' }), 'photo.jpg');
+
+    console.log('Sending to API', API_BASE + '/v1/ai/diagnose');
+    const apiResp = await fetch(API_BASE + '/v1/ai/diagnose', {
+      method: 'POST',
+      headers: { 'X-API-Key': API_KEY, 'X-API-Ver': API_VER },
+      body: form,
+    });
+    const data = await apiResp.json();
+    console.log('API response', data);
+
+    let text = `Культура: ${data.crop}\nБолезнь: ${data.disease}\nУверенность: ${(data.confidence * 100).toFixed(1)}%`;
+    if (data.protocol) {
+      text += `\nПрепарат: ${data.protocol.product}\nДоза: ${data.protocol.dosage_value} ${data.protocol.dosage_unit}\nPHI: ${data.protocol.phi}`;
+      await ctx.reply(text);
+    } else {
+      text += `\nБета`;
+      const keyboard = { inline_keyboard: [[{ text: 'Спросить эксперта', callback_data: 'ask_expert' }]] };
+      await ctx.reply(text, { reply_markup: keyboard });
+    }
+  } catch (err) {
+    console.error('diagnose error', err);
+    if (typeof ctx.reply === 'function') {
+      await ctx.reply('Ошибка диагностики');
+    }
   }
 }
 
@@ -22,4 +56,8 @@ function messageHandler(ctx) {
   }
 }
 
-module.exports = { photoHandler, messageHandler };
+function startHandler(ctx) {
+  ctx.reply('Отправьте фото листа для диагностики');
+}
+
+module.exports = { photoHandler, messageHandler, startHandler };

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -10,10 +10,19 @@ test('photoHandler stores info and replies', async () => {
     message: { photo: [{ file_id: 'id1', file_unique_id: 'uid', width: 1, height: 2, file_size: 3 }] },
     from: { id: 42 },
     reply: async (msg) => replies.push(msg),
+    telegram: { getFileLink: async () => ({ href: 'http://file' }) },
+  };
+  const origFetch = global.fetch;
+  global.fetch = async (url) => {
+    if (url === 'http://file') {
+      return { arrayBuffer: async () => Buffer.from('x') };
+    }
+    return { json: async () => ({ crop: 'apple', disease: 'scab', confidence: 0.9 }) };
   };
   await photoHandler(pool, ctx);
+  global.fetch = origFetch;
   assert.equal(calls.length, 1);
-  assert.equal(replies[0], 'Фото получено');
+  assert.ok(replies[0].includes('Культура'));
 });
 
 test('messageHandler ignores non-photo', () => {

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
-const { photoHandler, messageHandler } = require('./handlers');
+const { photoHandler, messageHandler, startHandler } = require('./handlers');
 
 const token = process.env.BOT_TOKEN_DEV;
 if (!token) {
@@ -11,8 +11,11 @@ if (!token) {
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const bot = new Telegraf(token);
 
+bot.start(startHandler);
+
 bot.on('photo', (ctx) => photoHandler(pool, ctx));
 
 bot.on('message', messageHandler);
 
 bot.launch().then(() => console.log('Bot started'));
+


### PR DESCRIPTION
## Summary
- implement Telegram bot start command and photo diagnosis flow
- send received photos to API using headers from env
- add env template entries for API settings
- update bot tests

## Testing
- `ruff check app/`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `node --test bot/handlers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687f1e0080fc832aae6131bab4fb72ab