### PR TITLE
Add result card with buttons to Telegram bot

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -9,7 +9,7 @@ test('photoHandler stores info and replies', async () => {
   const ctx = {
     message: { photo: [{ file_id: 'id1', file_unique_id: 'uid', width: 1, height: 2, file_size: 3 }] },
     from: { id: 42 },
-    reply: async (msg) => replies.push(msg),
+    reply: async (msg, opts) => replies.push({ msg, opts }),
     telegram: { getFileLink: async () => ({ href: 'http://file' }) },
   };
   const origFetch = global.fetch;
@@ -22,7 +22,8 @@ test('photoHandler stores info and replies', async () => {
   await photoHandler(pool, ctx);
   global.fetch = origFetch;
   assert.equal(calls.length, 1);
-  assert.ok(replies[0].includes('Культура'));
+  assert.ok(replies[0].msg.includes('Культура'));
+  assert.ok(replies[0].opts.reply_markup.inline_keyboard.length > 0);
 });
 
 test('messageHandler ignores non-photo', () => {

--- a/bot/index.js
+++ b/bot/index.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
 const { photoHandler, messageHandler, startHandler } = require('./handlers');
+const crypto = require('node:crypto');
 
 const token = process.env.BOT_TOKEN_DEV;
 if (!token) {
@@ -16,6 +17,18 @@ bot.start(startHandler);
 bot.on('photo', (ctx) => photoHandler(pool, ctx));
 
 bot.on('message', messageHandler);
+
+bot.action(/^proto\|/, (ctx) => {
+  const [, product, val, unit, phi] = ctx.callbackQuery.data.split('|');
+  const msg = `Препарат: ${product}\nДоза: ${val} ${unit}\nPHI: ${phi}`;
+  ctx.answerCbQuery();
+  return ctx.reply(msg);
+});
+
+bot.action('ask_expert', (ctx) => {
+  ctx.answerCbQuery();
+  return ctx.reply('Свяжитесь с экспертом для уточнения протокола.');
+});
 
 bot.launch().then(() => console.log('Bot started'));
 


### PR DESCRIPTION
## Summary
- show diagnose result card with inline buttons
- provide callback actions for protocol details and expert help
- update tests for new reply structure

## Testing
- `flake8 app/` *(fails: command not found)*
- `pytest -q` *(fails: missing dependencies)*
- `node bot/handlers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687f1ff65684832a8caa005cd2b00e3b