### PR TITLE
[ux] improve telegram card wording

### DIFF
--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -34,10 +34,13 @@ async function photoHandler(pool, ctx) {
     const data = await apiResp.json();
     console.log('API response', data);
 
-    const text =
+    let text =
       `Культура: ${data.crop}\n` +
-      `Болезнь: ${data.disease}\n` +
-      `Уверенность: ${(data.confidence * 100).toFixed(1)}%`;
+      `Диагноз: ${data.disease}\n` +
+      `Уверенность модели: ${(data.confidence * 100).toFixed(1)}%`;
+    if (data.protocol_status) {
+      text += `\n${data.protocol_status}`;
+    }
 
     let keyboard;
     if (data.protocol) {
@@ -48,7 +51,7 @@ async function photoHandler(pool, ctx) {
         data.protocol.dosage_unit,
         data.protocol.phi,
       ].join('|');
-      const row = [{ text: 'Протокол', callback_data: cb }];
+      const row = [{ text: 'Показать протокол', callback_data: cb }];
       if (data.protocol.id) {
         const urlBase = process.env.PARTNER_LINK_BASE ||
           'https://agrostore.example/agronom';
@@ -56,12 +59,12 @@ async function photoHandler(pool, ctx) {
           .update(String(ctx.from.id))
           .digest('hex');
         const link = `${urlBase}?pid=${data.protocol.id}&src=bot&uid=${uid}&dis=5&utm_campaign=agrobot`;
-        row.push({ text: 'Купить', url: link });
+        row.push({ text: 'Купить препарат', url: link });
       }
       keyboard = { inline_keyboard: [row] };
     } else {
       keyboard = {
-        inline_keyboard: [[{ text: 'Спросить эксперта', callback_data: 'ask_expert' }]],
+        inline_keyboard: [[{ text: 'Задать вопрос эксперту', callback_data: 'ask_expert' }]],
       };
     }
 

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -67,7 +67,7 @@ test('photoHandler sends protocol buttons', async () => {
   await photoHandler(pool, ctx);
   global.fetch = origFetch;
   const buttons = replies[0].opts.reply_markup.inline_keyboard[0];
-  assert.equal(buttons[0].text, 'Протокол');
+  assert.equal(buttons[0].text, 'Показать протокол');
   assert.equal(buttons[0].callback_data, 'proto|Скор 250 ЭК|2|ml_10l|30');
   assert.ok(buttons[1].url.includes('pid=1'));
 });

--- a/bot/index.js
+++ b/bot/index.js
@@ -20,7 +20,10 @@ bot.on('message', messageHandler);
 
 bot.action(/^proto\|/, (ctx) => {
   const [, product, val, unit, phi] = ctx.callbackQuery.data.split('|');
-  const msg = `Препарат: ${product}\nДоза: ${val} ${unit}\nPHI: ${phi}`;
+  const msg =
+    `Препарат: ${product}\n` +
+    `Доза: ${val} ${unit}\n` +
+    `Срок ожидания (PHI): ${phi} дней`;
   ctx.answerCbQuery();
   return ctx.reply(msg);
 });


### PR DESCRIPTION
## Summary
- refine result card copy
- tweak protocol button text
- update tests

## Testing
- `ruff check app`
- `node bot/handlers.test.js`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm install --prefix bot` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f3d5f620c832aa92b25c682c1f728