### PR TITLE
[fix] update photo status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -219,7 +219,7 @@ async def diagnose(
         crop=crop,
         disease=disease,
         confidence=conf,
-        status="processed",
+        status="ok",
     )
     db.add(photo)
     quota.used_count += 1


### PR DESCRIPTION
## Summary
- use valid status when creating Photo entries

## Testing
- `ruff check app/`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi, sqlalchemy, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_687f43610210832aad046499a9478be4