### PR TITLE
fix: clamp photo list limit

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -277,7 +277,7 @@ async def list_photos(
             db.close()
             raise HTTPException(status_code=400, detail="BAD_REQUEST")
 
-    limit = min(limit, 50)
+    limit = max(1, min(limit, 50))
     rows = q.limit(limit).all()
     items = [
         PhotoItem(

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -219,6 +219,7 @@ paths:
           schema:
             type: integer
             default: 10
+            minimum: 1
             maximum: 50
         - name: cursor
           in: query

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,6 +175,26 @@ def test_photos_unauthorized():
     assert resp.status_code in {401, 404}
 
 
+def test_photos_limit_zero_returns_one():
+    from app.db import SessionLocal
+    from app.models import Photo
+
+    session = SessionLocal()
+    session.query(Photo).delete()
+    session.add_all([
+        Photo(user_id=1, file_id="f1"),
+        Photo(user_id=1, file_id="f2"),
+    ])
+    session.commit()
+    session.close()
+
+    resp = client.get("/v1/photos?limit=0", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data.get("items", [])) == 1
+    assert data.get("next_cursor")
+
+
 def test_payment_webhook_success():
     payload = {
         "payment_id": "123",


### PR DESCRIPTION
## Summary
- clamp minimum `limit` in `/v1/photos`
- document minimal `limit` in OpenAPI spec
- test negative limit handling

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi, sqlalchemy, boto3)*
- `spectral lint openapi/openapi.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5a493c30832a80dcc0fcc8d3bc42