### PR TITLE
[fix] bump version to 1.4.0

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ from app.models import Photo, PhotoQuota, Payment, PartnerOrder
 
 app = FastAPI(
     title="Agronom Bot Internal API",
-    version="1.3.0"
+    version="1.4.0"
 )
 
 HMAC_SECRET = os.environ.get("HMAC_SECRET", "test-hmac-secret")


### PR DESCRIPTION
## Summary
- bump FastAPI app version to 1.4.0 so `/openapi.json` matches spec

## Testing
- `ruff check app/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f5f8d7f84832ab2e8bffee387493f