### PR TITLE
Improve error handling in API

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -170,6 +170,14 @@ def test_photos_success():
     assert resp.status_code == 200
 
 
+def test_photos_limit_zero():
+    resp = client.get("/v1/photos?limit=0", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"] == []
+    assert body["next_cursor"] is None
+
+
 def test_photos_unauthorized():
     resp = client.get("/v1/photos", headers={"X-API-Key": "bad", "X-API-Ver": "v1"})
     assert resp.status_code in {401, 404}


### PR DESCRIPTION
## Summary
- close DB sessions via context managers
- guard `limit` param in `/v1/photos`
- offload S3 upload to threadpool
- test zero limit edge case

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687f62189d98832a890487a6e696e52a