### PR TITLE
Add setup script for codex

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+pip install -r requirements.txt
+
+# Optionally install testing tools if not present in requirements
+if ! grep -qE '^pytest([=>< ]|$)' requirements.txt; then
+    pip install pytest
+fi
+
+if ! grep -qE '^ruff([=>< ]|$)' requirements.txt; then
+    pip install ruff
+fi

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,1 @@
+internet: true


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install project dependencies
- enable internet access for Codex with `codex.yaml`

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi, sqlalchemy, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_687f69458ff4832a8cbb1e4edea6ac7f