### PR TITLE
chore: ignore local database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pytest_cache/
 
 # DB (если SQLite используется локально)
 db.sqlite3
+app.db
 
 # Exported OpenAPI clients
 client/


### PR DESCRIPTION
## Summary
- ignore local `app.db`
- remove the tracked `app.db` file

## Testing
- `ruff check app/`
- `pytest` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_687f6c213df4832aa03c24493946da23