### PR TITLE
[fix] validate base64 decode

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -202,7 +202,7 @@ async def diagnose(
             except ValidationError:
                 err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
                 return JSONResponse(status_code=400, content=err.model_dump())
-            contents = base64.b64decode(body.image_base64)
+            contents = base64.b64decode(body.image_base64, validate=True)
             key = await run_in_threadpool(upload_photo, user_id, contents)
             result = call_gpt_vision_stub(key)
             crop = result.get("crop", "")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,6 +138,15 @@ def test_diagnose_json_missing_prompt():
     assert resp.status_code == 400
 
 
+def test_diagnose_invalid_base64():
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": "dGVzdA==@@", "prompt_id": "v1"},
+    )
+    assert resp.status_code != 200
+
+
 def test_diagnose_multipart_missing_image():
     resp = client.post(
         "/v1/ai/diagnose",


### PR DESCRIPTION
## Summary
- validate base64 input when decoding images
- add regression test for invalid base64

## Testing
- `flake8 app/` *(fails: command not found)*
- `ruff app/` *(fails: unrecognized subcommand)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f6ee720b0832aa18a95a0f5ecec30