### PR TITLE
[chore] add node tests to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,15 @@ jobs:
         run: ruff app tests
       - name: Run Tests
         run: pytest -q
+
+  bot-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install bot dependencies
+        run: npm ci --prefix bot
+      - name: Run bot tests
+        run: npm test --prefix bot

--- a/bot/package.json
+++ b/bot/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "commonjs",
   "main": "index.js",
+  "scripts": {
+    "test": "node handlers.test.js"
+  },
   "dependencies": {
     "dotenv": "^16.4.5",
     "pg": "^8.11.5",


### PR DESCRIPTION
## Summary
- add NPM test script for the Telegram bot
- run node tests in CI

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: ModuleNotFoundError: 'fastapi', 'sqlalchemy', 'boto3')*
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_687f70083298832abf6dc679b9adda29