### PR TITLE
Add Alembic run functions to env

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -24,3 +24,38 @@ if url is None:
     raise ValueError("DATABASE_URL environment variable not set")
 
 config.set_main_option("sqlalchemy.url", url)
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()


### PR DESCRIPTION
## Summary
- include `run_migrations_offline` and `run_migrations_online` in Alembic env.py

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `flake8 app/` *(fails: command not found)*
- `ruff app/` *(fails: unrecognized subcommand)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `alembic upgrade head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f733c7944832aa79ab58ae27fc5f3