### PR TITLE
[fix] ensure unique S3 object keys

### DIFF
--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from uuid import uuid4
 import boto3
 
 BUCKET = os.getenv("S3_BUCKET", "agronom")
@@ -18,7 +19,7 @@ def _client():
 def upload_photo(user_id: int, data: bytes) -> str:
     """Upload bytes to S3 and return the object key."""
     ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    key = f"{user_id}/{ts}.jpg"
+    key = f"{user_id}/{ts}-{uuid4().hex}.jpg"
     _client().put_object(Bucket=BUCKET, Key=key, Body=data, ContentType="image/jpeg")
     return key
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 import os
+import re
 import boto3
 
 from moto import mock_aws
@@ -17,7 +18,7 @@ def test_upload_and_url():
     s3.create_bucket(Bucket='testbucket')
 
     key = upload_photo(42, b'hello')
-    assert key.startswith('42/')
+    assert re.fullmatch(r"42/\d{14}-[0-9a-f]{32}\.jpg", key)
     obj = s3.get_object(Bucket='testbucket', Key=key)
     assert obj['Body'].read() == b'hello'
 


### PR DESCRIPTION
## Summary
- add a random suffix to S3 photo keys to avoid name clashes
- adjust storage tests for new key pattern

## Testing
- `ruff check app/ tests/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f747e5c9c832a9b44ca1a8574e905