### PR TITLE
[fix] suppress env.py lint warning

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -8,9 +8,9 @@ load_dotenv()
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # Импорт модели
-from app.models import Base  # ← убедись, что models.Base определён
-from alembic import context
-from sqlalchemy import engine_from_config, pool
+from app.models import Base  # ← убедись, что models.Base определён  # noqa: E402
+from alembic import context  # noqa: E402
+from sqlalchemy import engine_from_config, pool  # noqa: E402
 
 # Настройка метаданных
 target_metadata = Base.metadata


### PR DESCRIPTION
## Summary
- suppress ruff E402 warning in Alembic env

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f7beb82e8832a9b5d4028853916f1