### PR TITLE
docs(ci): mention setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest ruff
+          ./.codex/setup.sh
       - name: Run Ruff
         run: ruff app tests
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ agronom-bot/
    source .venv/bin/activate
    ```
 
-3. Установите зависимости и примените миграции:
+3. Установите зависимости (используйте скрипт `./.codex/setup.sh`) и примените миграции:
 
    ```bash
-   pip install -r requirements.txt
+   ./.codex/setup.sh
    alembic upgrade head
    ```
 
@@ -189,7 +189,7 @@ apple,powdery_mildew,Скор 250 ЭК,2,ml_10l,30
    ```bash
    python3.12 -m venv .venv
    source .venv/bin/activate
-   pip install -r requirements.txt
+   ./.codex/setup.sh
    ```
 📖 Документация
 Смотри в папке docs/:


### PR DESCRIPTION
## Summary
- run setup script in CI
- update local setup instructions to use `.codex/setup.sh`

## Testing
- `bash .codex/setup.sh` *(fails: Could not find a version that satisfies the requirement alembic==1.14.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f7d37fabc832a98211b93dc60f6c1