### PR TITLE
[fix] openapi: add diagnose 500 response

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -203,6 +203,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       x-rateLimit:
         limit: 30
         window: second


### PR DESCRIPTION
## Summary
- document unexpected internal error for `/v1/ai/diagnose`

## Testing
- `ruff check app/`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `spectral lint openapi/openapi.yaml` *(fails: spectral not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f7e887238832a8c0f820b0fc5fc5e