### PR TITLE
Handle invalid base64 input

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,7 +144,7 @@ def test_diagnose_invalid_base64():
         headers=HEADERS,
         json={"image_base64": "dGVzdA==@@", "prompt_id": "v1"},
     )
-    assert resp.status_code != 200
+    assert resp.status_code == 400
 
 
 def test_diagnose_multipart_missing_image():


### PR DESCRIPTION
## Summary
- catch `binascii.Error` when decoding base64 images
- return `BAD_REQUEST` if decode fails
- test invalid base64 input

## Testing
- `ruff check app/ tests/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_687f8488fb1c832a94de0b53f6b66de5