### PR TITLE
fix(bot): gracefully close connections

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -35,3 +35,12 @@ bot.action('ask_expert', (ctx) => {
 
 bot.launch().then(() => console.log('Bot started'));
 
+// Gracefully close DB connections on termination
+async function shutdown() {
+  await pool.end();
+  process.exit(0);
+}
+
+process.once('SIGINT', shutdown);
+process.once('SIGTERM', shutdown);
+


### PR DESCRIPTION
## Summary
- listen for SIGINT and SIGTERM in `bot/index.js`
- close PostgreSQL pool when exiting

## Testing
- `ruff check app/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `node bot/handlers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687f8747f298832a8f84f90237492fb7