### PR TITLE
[refactor] move csv import to lifespan

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Header, UploadFile, File, Request, HTTPException, Form
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator, ValidationError
+from contextlib import asynccontextmanager
 from datetime import datetime
 import base64
 import binascii
@@ -19,18 +20,20 @@ from app.models import Photo, PhotoQuota, Payment, PartnerOrder
 
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Run startup tasks for the application."""
+    import_csv_to_db()
+    yield
+
+
 app = FastAPI(
     title="Agronom Bot Internal API",
     version="1.4.0",
+    lifespan=lifespan,
 )
 
 HMAC_SECRET = os.environ.get("HMAC_SECRET", "test-hmac-secret")
-
-
-@app.on_event("startup")
-def startup_event() -> None:
-    """Populate protocol table from CSV if empty."""
-    import_csv_to_db()
 
 # -------------------------------
 # Pydantic Schemas (по OpenAPI)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,17 @@
 import subprocess
 import pytest
+from fastapi.testclient import TestClient
+from app.main import app
 
 @pytest.fixture(scope="session", autouse=True)
 def apply_migrations():
     """Apply Alembic migrations before running tests."""
     subprocess.run(["alembic", "upgrade", "head"], check=True)
+
+
+@pytest.fixture(scope="module")
+def client(apply_migrations):
+    """Yields a TestClient with lifespan events."""
+    with TestClient(app) as client:
+        yield client
 


### PR DESCRIPTION
## Summary
- use FastAPI lifespan handler
- create client fixture for tests
- adjust tests to rely on fixture

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: S3 bucket/credentials issues)*

------
https://chatgpt.com/codex/tasks/task_e_687f8bada42c832a9da820ac8ff83c01