### PR TITLE
Add pytest-asyncio support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           ./.codex/setup.sh
+          pip install pytest-asyncio
       - name: Run Ruff
         run: ruff app tests
       - name: Run Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ python-dotenv
 httpx==0.27.0
 boto3==1.34.113
 moto[s3]==5.0.12
+pytest-asyncio==1.1.0


### PR DESCRIPTION
## Summary
- add `pytest-asyncio` to requirements
- install it in CI

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: CalledProcessError: Command '['alembic', 'upgrade', 'head']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_687f8fbdbaec832aa2623cce3c1840c4