### PR TITLE
[test] stub S3 uploads in diagnose tests

### DIFF
--- a/app/services/protocols.py
+++ b/app/services/protocols.py
@@ -9,7 +9,8 @@ from functools import lru_cache
 from app.db import SessionLocal
 from app.models import Protocol
 
-CSV_PATH = Path(__file__).resolve().parent.parent / "protocols.csv"
+# CSV is stored in the repository root
+CSV_PATH = Path(__file__).resolve().parent.parent.parent / "protocols.csv"
 
 
 def load_csv(path: Path = CSV_PATH) -> list[dict]:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,6 +6,7 @@ import pytest
 from moto import mock_aws
 
 from fastapi import HTTPException
+from app.services import storage
 from app.services.storage import upload_photo, get_public_url
 
 
@@ -22,6 +23,8 @@ def test_upload_and_url():
         os.environ["S3_REGION"] = "us-east-1"
         os.environ.pop("S3_ENDPOINT", None)
         os.environ["S3_PUBLIC_URL"] = "http://localhost:9000"
+        # update module constant to match env
+        storage.BUCKET = "testbucket"
 
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="testbucket")
@@ -54,6 +57,7 @@ def test_upload_failure():
         os.environ["S3_REGION"] = "us-east-1"
         os.environ.pop("S3_ENDPOINT", None)
         os.environ.pop("S3_PUBLIC_URL", None)
+        storage.BUCKET = "testbucket"
 
         # Intentionally do not create bucket to trigger error
         with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Summary
- avoid S3 calls in diagnose endpoint tests by stubbing `upload_photo`
- reset protocol cache and quota counters between tests
- point protocol CSV path to repo root
- fix storage tests for static bucket name

## Testing
- `ruff check app tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f91075d88832a95f8fb35d927756a