### PR TITLE
Add Spectral ruleset

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,25 @@
+extends: ["spectral:oas"]
+
+rules:
+  info-contact:
+    description: "info object must have contact details"
+    given: "$.info"
+    then:
+      field: contact
+      function: truthy
+  https-server-url:
+    description: "Server URLs must use HTTPS"
+    message: "Server URL {{value}} must start with https://"
+    given: "$.servers[*].url"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^https://"
+  semantic-version:
+    description: "info.version must follow semantic versioning"
+    message: "Version {{value}} should be semantic"
+    given: "$.info.version"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?:\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?$"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ agronom-bot/
    При отсутствии переменной окружения `DATABASE_URL` тесты используют
    SQLite файл `./test.db`.
 
+7. Проверьте спецификацию OpenAPI линтером Spectral:
+
+   ```bash
+   spectral lint -r .spectral.yaml openapi/openapi.yaml
+   ```
+
+
 ### Добавление протокола обработки
 
 Файл `protocols.csv` лежит в корне репозитория. Формат строк:


### PR DESCRIPTION
## Summary
- add project-specific Spectral ruleset
- document `spectral lint` usage in README

## Testing
- `ruff check app`
- `pytest -q`
- `npx -y @stoplight/spectral-cli lint -r .spectral.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_687f9a1c0670832a873e198322193927