### PR TITLE
[fix] read API key from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ OpenAPI см. в `openapi/openapi.yaml`
 
 ### Пример запроса `/v1/ai/diagnose`
 
+API-ключ берётся из переменной окружения `API_KEY` (по умолчанию `test-api-key`).
+
 ```bash
 curl -X POST http://localhost:8000/v1/ai/diagnose \
-  -H "X-API-Key: test-api-key" \
+  -H "X-API-Key: $API_KEY" \
   -H "X-API-Ver: v1" \
   -H "Content-Type: application/json" \
   -d '{"image_base64":"dGVzdA==","prompt_id":"v1"}'

--- a/app/main.py
+++ b/app/main.py
@@ -110,8 +110,9 @@ async def verify_headers(
 ):
     if x_api_ver != "v1":
         raise HTTPException(status_code=400, detail="Invalid API version")
-    # Здесь можно добавить валидацию ключа
-    if x_api_key != "test-api-key":
+    # Validate API key against env var
+    api_key = os.getenv("API_KEY", "test-api-key")
+    if x_api_key != api_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 async def verify_version(x_api_ver: str = Header(..., alias="X-API-Ver")):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import json
 import pytest
 from starlette.requests import Request
 from app.main import compute_signature, verify_hmac
+import os
 from app.services.protocols import import_csv_to_db
 
 
@@ -24,7 +25,7 @@ def stub_upload(monkeypatch):
 
     _cache_protocol.cache_clear()
 
-HEADERS = {"X-API-Key": "test-api-key", "X-API-Ver": "v1"}
+HEADERS = {"X-API-Key": os.getenv("API_KEY", "test-api-key"), "X-API-Ver": "v1"}
 
 
 def test_openapi_schema(client):


### PR DESCRIPTION
## Summary
- fetch API key from the `API_KEY` environment variable
- update docs with `$API_KEY` curl example
- reference env variable in tests

## Testing
- `ruff check app/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9dd2bb28832a94176b48cf9bd349