### PR TITLE
fix: limit base64 diagnose uploads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -216,6 +216,9 @@ async def diagnose(
             except binascii.Error:
                 err = ErrorResponse(code="BAD_REQUEST", message="invalid base64")
                 return JSONResponse(status_code=400, content=err.model_dump())
+            if len(contents) > 2 * 1024 * 1024:
+                err = ErrorResponse(code="BAD_REQUEST", message="image too large")
+                return JSONResponse(status_code=400, content=err.model_dump())
             key = await run_in_threadpool(upload_photo, user_id, contents)
             result = call_gpt_vision_stub(key)
             crop = result.get("crop", "")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+import base64
 import pytest
 from starlette.requests import Request
 from app.main import compute_signature, verify_hmac
@@ -92,6 +93,17 @@ def test_diagnose_large_image(client):
         "/v1/ai/diagnose",
         headers=HEADERS,
         files={"image": ("big.jpg", large, "image/jpeg")},
+    )
+    assert resp.status_code == 400
+
+
+def test_diagnose_large_base64(client):
+    large_bytes = b"0" * (2 * 1024 * 1024 + 1)
+    encoded = base64.b64encode(large_bytes).decode()
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": encoded, "prompt_id": "v1"},
     )
     assert resp.status_code == 400
 


### PR DESCRIPTION
## Summary
- validate size of base64 payloads in /v1/ai/diagnose
- reject oversized JSON images
- test image size check for JSON uploads

## Testing
- `ruff check app tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb8f608f4832abaa137a96d1915f0