### PR TITLE
[fix] update codegen prompt

### DIFF
--- a/prompts/codegen_prompt.md
+++ b/prompts/codegen_prompt.md
@@ -1,6 +1,6 @@
 # Codegen Prompt for Cursor
 
-Ты пишешь код строго по OpenAPI v1.3.0 (см. `openapi/openapi.yaml`).
+Ты пишешь код строго по OpenAPI v1.4.0 (см. `openapi/openapi.yaml`).
 Не выдумывай схем и эндпоинтов — используй только те, что описаны.
 
 Каждый эндпоинт должен:


### PR DESCRIPTION
## Summary
- reference the latest API schema in the codegen prompt

## Testing
- `ruff check app/`
- `pytest -q`
- `spectral lint openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_687fd1f44868832aa31b16120bc9a9ad