### PR TITLE
[fix] protocols import warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ agronom-bot/
    ./.codex/setup.sh
    alembic upgrade head
    ```
+   Если пропустить этот шаг и таблица `protocols` не будет создана, функция
+   `import_csv_to_db()` просто выдаст предупреждение в лог и посоветует
+   выполнить `alembic upgrade head` или запустить приложение с переменной
+   `DB_CREATE_ALL=1`.
 
 4. Запустите API:
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,4 +1,16 @@
 from app.services.protocols import find_protocol, import_csv_to_db
+from app.db import SessionLocal
+from app.models import Protocol
+
+
+def test_import_csv_no_table():
+    engine = SessionLocal().bind
+    Protocol.__table__.drop(engine)
+    try:
+        import_csv_to_db()
+    finally:
+        Protocol.__table__.create(engine)
+        import_csv_to_db()
 
 
 def test_find_protocol_found():


### PR DESCRIPTION
## Summary
- handle missing protocol table gracefully by logging a warning
- test import_csv_to_db without the table
- document warning in README

## Testing
- `ruff check app tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688054cc3ae0832ab19503781194382e