### PR TITLE
[fix] consistent error responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -123,16 +123,19 @@ async def verify_headers(
     x_api_ver: str = Header(..., alias="X-API-Ver")
 ):
     if x_api_ver != "v1":
-        raise HTTPException(status_code=400, detail="Invalid API version")
+        err = ErrorResponse(code="BAD_REQUEST", message="Invalid API version")
+        raise HTTPException(status_code=400, detail=err.model_dump())
     # Validate API key against env var
     api_key = os.getenv("API_KEY", "test-api-key")
     if x_api_key != api_key:
-        raise HTTPException(status_code=401, detail="Invalid API key")
+        err = ErrorResponse(code="UNAUTHORIZED", message="Invalid API key")
+        raise HTTPException(status_code=401, detail=err.model_dump())
 
 
 async def verify_version(x_api_ver: str = Header(..., alias="X-API-Ver")):
     if x_api_ver != "v1":
-        raise HTTPException(status_code=400, detail="Invalid API version")
+        err = ErrorResponse(code="BAD_REQUEST", message="Invalid API version")
+        raise HTTPException(status_code=400, detail=err.model_dump())
 
 
 def verify_hmac_signature(body: bytes, provided: str) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -85,6 +85,7 @@ def test_diagnose_invalid_key(client):
         json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
     )
     assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "UNAUTHORIZED"
 
 
 def test_diagnose_large_image(client):
@@ -202,6 +203,8 @@ def test_quota_exceeded(client):
 def test_limits_unauthorized(client):
     resp = client.get("/v1/limits", headers={"X-API-Key": "bad", "X-API-Ver": "v1"})
     assert resp.status_code in {401, 404}
+    if resp.status_code == 401:
+        assert resp.json()["detail"]["code"] == "UNAUTHORIZED"
 
 
 def test_photos_success(client):
@@ -220,6 +223,8 @@ def test_photos_limit_zero(client):
 def test_photos_unauthorized(client):
     resp = client.get("/v1/photos", headers={"X-API-Key": "bad", "X-API-Ver": "v1"})
     assert resp.status_code in {401, 404}
+    if resp.status_code == 401:
+        assert resp.json()["detail"]["code"] == "UNAUTHORIZED"
 
 
 def test_payment_webhook_success(client):


### PR DESCRIPTION
## Summary
- raise `ErrorResponse` dicts in `verify_headers` and `verify_version`
- test unauthorized cases by checking `ErrorResponse.code`

## Testing
- `ruff check app/ tests/test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883beaa88e8832a9437faea35694354