### PR TITLE
[refactor] centralize settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    hmac_secret: str = "test-hmac-secret"
+    free_monthly_limit: int = 5
+
+    api_key: str = "test-api-key"
+
+    database_url: str = "sqlite:///./app.db"
+    db_create_all: bool = False
+
+    s3_bucket: str = "agronom"
+    s3_endpoint: str | None = None
+    s3_region: str = "us-east-1"
+    s3_access_key: str | None = None
+    s3_secret_key: str | None = None
+    s3_public_url: str | None = None
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False

--- a/app/db.py
+++ b/app/db.py
@@ -3,9 +3,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.models import Base
+from app.config import Settings
+
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
-
 engine = create_engine(DATABASE_URL, future=True)
 SessionLocal = sessionmaker(
     bind=engine,
@@ -13,6 +14,23 @@ SessionLocal = sessionmaker(
     autocommit=False,
     future=True,
 )
+
+
+def init_db(cfg: Settings) -> None:
+    """Configure engine and session factory using provided settings."""
+    global engine, SessionLocal
+
+    engine = create_engine(cfg.database_url, future=True)
+    SessionLocal = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        future=True,
+    )
+
+    if cfg.db_create_all:
+        Base.metadata.create_all(engine)
+
 
 # Optionally create tables automatically when DB_CREATE_ALL is set
 if os.getenv("DB_CREATE_ALL"):

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,20 +1,48 @@
 import os
 from datetime import datetime
 from uuid import uuid4
+
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 from fastapi import HTTPException
 
+from app.config import Settings
+
+
+
 BUCKET = os.getenv("S3_BUCKET", "agronom")
+_settings: Settings | None = None
+
+
+def init_storage(cfg: Settings) -> None:
+    """Store settings for later use."""
+    global _settings
+    _settings = cfg
 
 
 def _client():
+    endpoint = os.getenv(
+        "S3_ENDPOINT",
+        _settings.s3_endpoint if _settings is not None else None,
+    )
+    region = os.getenv(
+        "S3_REGION",
+        _settings.s3_region if _settings is not None else "us-east-1",
+    )
+    access_key = os.getenv(
+        "S3_ACCESS_KEY",
+        _settings.s3_access_key if _settings is not None else None,
+    )
+    secret_key = os.getenv(
+        "S3_SECRET_KEY",
+        _settings.s3_secret_key if _settings is not None else None,
+    )
     return boto3.client(
         "s3",
-        endpoint_url=os.getenv("S3_ENDPOINT"),
-        region_name=os.getenv("S3_REGION", "us-east-1"),
-        aws_access_key_id=os.getenv("S3_ACCESS_KEY"),
-        aws_secret_access_key=os.getenv("S3_SECRET_KEY"),
+        endpoint_url=endpoint,
+        region_name=region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
     )
 
 
@@ -22,9 +50,13 @@ def upload_photo(user_id: int, data: bytes) -> str:
     """Upload bytes to S3 and return the object key."""
     ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     key = f"{user_id}/{ts}-{uuid4().hex}.jpg"
+    bucket = os.getenv(
+        "S3_BUCKET",
+        _settings.s3_bucket if _settings is not None else BUCKET,
+    )
     try:
         _client().put_object(
-            Bucket=BUCKET, Key=key, Body=data, ContentType="image/jpeg"
+            Bucket=bucket, Key=key, Body=data, ContentType="image/jpeg"
         )
     except (BotoCoreError, ClientError) as exc:
         raise HTTPException(
@@ -36,13 +68,26 @@ def upload_photo(user_id: int, data: bytes) -> str:
 
 def get_public_url(key: str) -> str:
     """Return a public URL for the object."""
-    base = os.getenv("S3_PUBLIC_URL")
+    bucket = os.getenv(
+        "S3_BUCKET",
+        _settings.s3_bucket if _settings is not None else BUCKET,
+    )
+    base = os.getenv(
+        "S3_PUBLIC_URL",
+        _settings.s3_public_url if _settings is not None else None,
+    )
     if base:
         return f"{base.rstrip('/')}/{key}"
 
-    endpoint = os.getenv("S3_ENDPOINT")
+    endpoint = os.getenv(
+        "S3_ENDPOINT",
+        _settings.s3_endpoint if _settings is not None else None,
+    )
     if endpoint:
-        return f"{endpoint.rstrip('/')}/{BUCKET}/{key}"
+        return f"{endpoint.rstrip('/')}/{bucket}/{key}"
 
-    region = os.getenv("S3_REGION", "us-east-1")
-    return f"https://{BUCKET}.s3.{region}.amazonaws.com/{key}"
+    region = os.getenv(
+        "S3_REGION",
+        _settings.s3_region if _settings is not None else "us-east-1",
+    )
+    return f"https://{bucket}.s3.{region}.amazonaws.com/{key}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ boto3==1.34.113
 moto[s3]==5.0.12
 pytest-asyncio==1.1.0
 requests==2.32.4
+pydantic-settings==2.2.1


### PR DESCRIPTION
## Summary
- introduce `app.config.Settings` using Pydantic BaseSettings
- instantiate once inside `app.main`
- pass config to DB and storage modules
- update requirements

## Testing
- `ruff check app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c3044268832aa2598a32ba5552b7