### PR TITLE
fix: pin uvicorn to existing version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ sniffio==1.3.1
 SQLAlchemy==2.0.41
 starlette==0.44.0
 typing_extensions==4.13.2
-uvicorn==0.34.0
+uvicorn==0.33.0
 zipp==3.20.2
 python-dotenv
 


### PR DESCRIPTION
## Summary
- fix uvicorn version in requirements

## Testing
- `ruff check app tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688459fa89e0832aba1e3e455b6022f7