### PR TITLE
[test] close session during protocol import table drop

### DIFF
--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -4,7 +4,10 @@ from app.models import Protocol
 
 
 def test_import_csv_no_table():
-    engine = SessionLocal().bind
+    """Drop protocols table to verify CSV import recreates it."""
+    with SessionLocal() as session:
+        engine = session.bind
+
     Protocol.__table__.drop(engine)
     try:
         import_csv_to_db()


### PR DESCRIPTION
## Summary
- ensure SessionLocal is closed in `test_import_csv_no_table`

## Testing
- `ruff check app/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884608387b0832a88cd2cacf5210d73