### PR TITLE
fix: timezone-aware timestamps

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from fastapi import (
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator, ValidationError
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 import base64
 import binascii
 import json
@@ -213,7 +213,7 @@ async def diagnose(
     user_id = 1  # в MVP ключ привязан к одному пользователю
 
     with SessionLocal() as db:
-        month = datetime.utcnow().strftime("%Y-%m")
+        month = datetime.now(timezone.utc).strftime("%Y-%m")
         quota = (
             db.query(PhotoQuota)
             .filter_by(user_id=user_id, month_year=month)
@@ -397,7 +397,7 @@ async def get_limits(
     """Return remaining free quota for the current month."""
     user_id = 1
     with SessionLocal() as db:
-        month = datetime.utcnow().strftime("%Y-%m")
+        month = datetime.now(timezone.utc).strftime("%Y-%m")
         quota = (
             db.query(PhotoQuota)
             .filter_by(user_id=user_id, month_year=month)

--- a/app/models/partner_order.py
+++ b/app/models/partner_order.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, DateTime
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.models.base import Base
 
@@ -13,5 +13,5 @@ class PartnerOrder(Base):
     protocol_id = Column(Integer)
     price_kopeks = Column(Integer)
     signature = Column(String)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     status = Column(String, default="new")

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, Enum
 from app.models.base import Base
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Payment(Base):
@@ -14,4 +14,4 @@ class Payment(Base):
         Enum("success", "fail", "cancel", "bank_error", name="payment_status"),
         nullable=False,
     )
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/app/models/photo.py
+++ b/app/models/photo.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, Enum
 from app.models.base import Base
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Photo(Base):
@@ -21,5 +21,5 @@ class Photo(Base):
         nullable=False,
         server_default="pending",
     )
-    ts = Column(DateTime, default=datetime.utcnow)
+    ts = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     deleted = Column(Boolean, default=False)

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import boto3
@@ -52,7 +52,7 @@ def init_storage(cfg: Settings) -> None:
 
 def upload_photo(user_id: int, data: bytes) -> str:
     """Upload bytes to S3 and return the object key."""
-    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
     key = f"{user_id}/{ts}-{uuid4().hex}.jpg"
     bucket = os.getenv(
         "S3_BUCKET",


### PR DESCRIPTION
## Summary
- use `datetime.now(timezone.utc)` everywhere instead of `utcnow`
- adjust storage timestamp generation
- update model defaults

## Testing
- `ruff check app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688469470ef0832aa595b5176c8fee35