### PR TITLE
refactor: alias Settings fields

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pydantic_settings import BaseSettings
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 
 class Settings(BaseSettings):
@@ -12,8 +12,8 @@ class Settings(BaseSettings):
 
     api_key: str = "test-api-key"
 
-    database_url: str = "sqlite:///./app.db"
-    db_create_all: bool = False
+    database_url: str = Field("sqlite:///./app.db", alias="DATABASE_URL")
+    db_create_all: bool = Field(False, alias="DB_CREATE_ALL")
 
     s3_bucket: str = "agronom"
     s3_endpoint: str | None = None


### PR DESCRIPTION
## Summary
- alias `database_url` and `db_create_all` in config

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847e55b3a8832a8c1223439d4718fe