### PR TITLE
docs: clarify dev requirements install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ agronom-bot/
 
 **Потребуется Node.js 18+** — используется для Telegram‑бота и тестов.
 
-3. Установите зависимости командой `./.codex/setup.sh` и дополнительные пакеты для тестов из `requirements-dev.txt`. Перед запуском приложения обязательно примените миграции:
+3. Установите зависимости командой `./.codex/setup.sh` и дополнительные пакеты для тестов из `requirements-dev.txt`. Команду `pip install -r ./requirements-dev.txt` запускайте **из корня репозитория**. Перед запуском приложения обязательно примените миграции:
 
    ```bash
    ./.codex/setup.sh
-   pip install -r requirements-dev.txt
+   pip install -r ./requirements-dev.txt
    alembic upgrade head
    ```
    Если пропустить этот шаг и таблица `protocols` не будет создана, функция


### PR DESCRIPTION
## Summary
- clarify that `pip install -r requirements-dev.txt` must be run from the repository root in setup instructions

## Testing
- `ruff check app/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a6c80ea4832a8eff202d686d9147