### PR TITLE
fix: pin dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-fastapi
-pytest
-ruff
+fastapi==0.116.1
+pytest==8.4.1
+ruff==0.12.4


### PR DESCRIPTION
## Summary
- pin FastAPI version to match runtime
- specify pytest and ruff versions for deterministic installs

## Testing
- `ruff check app tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884a77dad04832aa927934bc53ac1db