### PR TITLE
[fix] cleanup settings loading

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,14 +1,7 @@
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
 from pydantic import ConfigDict, Field
-from dotenv import load_dotenv
-load_dotenv(dotenv_path=".env")
-
-from __future__ import annotations
-
 from pydantic_settings import BaseSettings
-from pydantic import ConfigDict, Field
 
 
 class Settings(BaseSettings):

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,11 @@
+import base64
+import binascii
+import hmac
+import hashlib
+import json
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
 from fastapi import (
     FastAPI,
     Header,
@@ -8,31 +16,20 @@ from fastapi import (
     Form,
     Depends,
 )
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, field_validator, ValidationError
-from contextlib import asynccontextmanager
-from datetime import datetime, timezone
-import base64
-import binascii
-import json
-import hmac
-import hashlib
+from pydantic import BaseModel, ValidationError, field_validator
 
 from app.config import Settings
-from app.db import SessionLocal, init_db  # noqa: E402
+from app.db import SessionLocal, init_db
+from app.models import Payment, PartnerOrder, Photo, PhotoQuota
+from app.services.gpt import call_gpt_vision_stub
+from app.services.protocols import find_protocol, import_csv_to_db
+from app.services.storage import init_storage, upload_photo
+
 settings = Settings()
-init_db(settings) 
-from app.services.storage import upload_photo, init_storage  # noqa: E402
-from app.services.gpt import call_gpt_vision_stub  # noqa: E402
-
-from app.services.protocols import find_protocol, import_csv_to_db  # noqa: E402
-from fastapi.concurrency import run_in_threadpool
-
-from app.models import Photo, PhotoQuota, Payment, PartnerOrder  # noqa: E402
-
-
+init_db(settings)
 init_storage(settings)
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):


### PR DESCRIPTION
## Summary
- remove duplicate imports and manual dotenv loading
- reorder imports in `main.py` and instantiate settings after them
- initialize DB and storage using settings

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884fb5b67a4832a8b6b8b9532fba7b6