### PR TITLE
Add /subscribe command to bot

### DIFF
--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -4,6 +4,20 @@ const API_VER = process.env.API_VER || 'v1';
 const crypto = require('node:crypto');
 
 /**
+ * Send paywall message with subscription links.
+ */
+function sendPaywall(ctx) {
+  return ctx.reply('Бесплатный лимит 5 фото/мес исчерпан', {
+    reply_markup: {
+      inline_keyboard: [[
+        { text: 'Купить PRO (199 ₽/мес)', url: 'https://t.me/YourBot?start=paywall' },
+        { text: 'Подробнее', url: 'https://t.me/YourBot?start=faq' },
+      ]],
+    },
+  });
+}
+
+/**
  * Handle incoming photo messages.
  * Downloads the photo, sends it to the API and replies with diagnosis.
  */
@@ -36,14 +50,7 @@ async function photoHandler(pool, ctx) {
       body: form,
     });
     if (apiResp.status === 402) {
-      await ctx.reply('Бесплатный лимит 5 фото/мес исчерпан', {
-        reply_markup: {
-          inline_keyboard: [[
-            { text: 'Купить PRO (199 ₽/мес)', url: 'https://t.me/YourBot?start=paywall' },
-            { text: 'Подробнее', url: 'https://t.me/YourBot?start=faq' },
-          ]],
-        },
-      });
+      await sendPaywall(ctx);
       return;
     }
     const data = await apiResp.json();
@@ -108,4 +115,11 @@ function startHandler(ctx) {
   ctx.reply('Отправьте фото листа для диагностики');
 }
 
-module.exports = { photoHandler, messageHandler, startHandler };
+/**
+ * Temporary stub for subscription command.
+ */
+function subscribeHandler(ctx) {
+  return sendPaywall(ctx);
+}
+
+module.exports = { photoHandler, messageHandler, startHandler, subscribeHandler };

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const { test } = require('node:test');
-const { photoHandler, messageHandler } = require('./handlers');
+const { photoHandler, messageHandler, subscribeHandler } = require('./handlers');
 
 async function withMockFetch(responses, fn) {
   const origFetch = global.fetch;
@@ -118,6 +118,16 @@ test('photoHandler paywall on 402', async () => {
   }, async () => {
     await photoHandler(pool, ctx);
   });
+  assert.equal(replies[0].msg, 'Бесплатный лимит 5 фото/мес исчерпан');
+  const btns = replies[0].opts.reply_markup.inline_keyboard[0];
+  assert.equal(btns[0].url, 'https://t.me/YourBot?start=paywall');
+  assert.equal(btns[1].url, 'https://t.me/YourBot?start=faq');
+});
+
+test('subscribeHandler shows paywall', async () => {
+  const replies = [];
+  const ctx = { reply: async (msg, opts) => replies.push({ msg, opts }) };
+  await subscribeHandler(ctx);
   assert.equal(replies[0].msg, 'Бесплатный лимит 5 фото/мес исчерпан');
   const btns = replies[0].opts.reply_markup.inline_keyboard[0];
   assert.equal(btns[0].url, 'https://t.me/YourBot?start=paywall');

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
-const { photoHandler, messageHandler, startHandler } = require('./handlers');
+const { photoHandler, messageHandler, startHandler, subscribeHandler } = require('./handlers');
 const crypto = require('node:crypto');
 
 const token = process.env.BOT_TOKEN_DEV;
@@ -13,6 +13,8 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const bot = new Telegraf(token);
 
 bot.start(startHandler);
+
+bot.command('subscribe', subscribeHandler);
 
 bot.on('photo', (ctx) => photoHandler(pool, ctx));
 


### PR DESCRIPTION
## Summary
- implement helper `sendPaywall` to reuse paywall reply
- add `subscribeHandler` and expose it from handlers
- register `/subscribe` command in the Telegram bot
- test paywall message for `/subscribe`

## Testing
- `ruff check app/`
- `pytest -q`
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_688511708578832aa31a254d11571c5a