### PR TITLE
config: make telegram photo limit configurable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -80,3 +80,5 @@ S3_PUBLIC_URL=http://localhost:9000
 # LANG=ru_RU.UTF-8
 # Number of free diagnoses per month
 FREE_MONTHLY_LIMIT=5
+# Number of free photos for Telegram bot per month
+FREE_PHOTO_LIMIT=5

--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -3,11 +3,16 @@ const API_KEY = process.env.API_KEY || 'test-api-key';
 const API_VER = process.env.API_VER || 'v1';
 const crypto = require('node:crypto');
 
+function getLimit() {
+  return parseInt(process.env.FREE_PHOTO_LIMIT || '5', 10);
+}
+
 /**
  * Send paywall message with subscription links.
  */
 function sendPaywall(ctx) {
-  return ctx.reply('Бесплатный лимит 5 фото/мес исчерпан', {
+  const limit = getLimit();
+  return ctx.reply(`Бесплатный лимит ${limit} фото/мес исчерпан`, {
     reply_markup: {
       inline_keyboard: [[
         { text: 'Купить PRO (199 ₽/мес)', url: 'https://t.me/YourBot?start=paywall' },


### PR DESCRIPTION
## Summary
- use FREE_PHOTO_LIMIT env var in bot handlers
- update tests to set FREE_PHOTO_LIMIT
- document FREE_PHOTO_LIMIT in `.env.template`

## Testing
- `ruff check app/`
- `pytest -q`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688514d4af4c832aa208ee0f7db3f613