### PR TITLE
[feature] add paywall analytics events

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,6 +5,7 @@ from .payment import Payment
 from .partner_order import PartnerOrder
 from .protocol import Protocol
 from .photo_usage import PhotoUsage
+from .event import Event
 
 __all__ = [
     "Base",
@@ -14,4 +15,5 @@ __all__ = [
     "Payment",
     "PartnerOrder",
     "Protocol",
+    "Event",
 ]

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -1,0 +1,15 @@
+from datetime import datetime, timezone
+from sqlalchemy import Column, Integer, String, DateTime
+
+from .base import Base
+
+
+class Event(Base):
+    """Analytics event."""
+
+    __tablename__ = "events"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, nullable=False)
+    event = Column(String, nullable=False)
+    ts = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/bot/index.js
+++ b/bot/index.js
@@ -12,9 +12,9 @@ if (!token) {
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const bot = new Telegraf(token);
 
-bot.start(startHandler);
+bot.start((ctx) => startHandler(ctx, pool));
 
-bot.command('subscribe', subscribeHandler);
+bot.command('subscribe', (ctx) => subscribeHandler(ctx, pool));
 
 bot.on('photo', (ctx) => photoHandler(pool, ctx));
 

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -1,6 +1,6 @@
 Data Contract – «Карманный агроном» (Bot‑Phase)
-Version 1.5 — 26 July 2025
-(v1.4 → v1.5: added photo_usage table, pro_expires_at in users)
+Version 1.6 — 26 July 2025
+(v1.5 → v1.6: added events table for analytics)
 0 · Scope
 Документ фиксирует схему БД, правила хранения, линии происхождения данных и JSON‑контракты API для MVP Telegram‑бота.
 1 · Storage & Retention
@@ -22,6 +22,8 @@ id PK, user_id FK, order_id TEXT, protocol_id INT, price_kopeks INT, signature T
 user_id PK, used_count INT, month_year CHAR(7)
 3.7 photo_usage (NEW)
 user_id PK, month CHAR(7) PK, used INT, updated_at TIMESTAMP
+3.8 events (NEW)
+id PK, user_id INT, event TEXT, ts TIMESTAMP
 4 · Enum Definitions
 CREATE TYPE payment_status AS ENUM ('success','fail','cancel','bank_error');CREATE TYPE photo_status   AS ENUM ('pending','ok','retrying');CREATE TYPE order_status   AS ENUM ('new','processed','cancelled');CREATE TYPE error_code     AS ENUM ('NO_LEAF', 'LIMIT_EXCEEDED', 'GPT_TIMEOUT', 'BAD_REQUEST', 'UNAUTHORIZED');
 5 · Data Lifecycle

--- a/migrations/versions/f68b39e27e92_add_events_table.py
+++ b/migrations/versions/f68b39e27e92_add_events_table.py
@@ -1,0 +1,31 @@
+"""add events table
+
+Revision ID: f68b39e27e92
+Revises: 799a9ae59498
+Create Date: 2025-07-26 18:44:12.508280
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f68b39e27e92'
+down_revision = '799a9ae59498'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create events table."""
+    op.create_table(
+        'events',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, nullable=False),
+        sa.Column('event', sa.String, nullable=False),
+        sa.Column('ts', sa.DateTime, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    """Drop events table."""
+    op.drop_table('events')


### PR DESCRIPTION
## Summary
- add `Event` model and alembic migration
- log paywall interactions in the bot
- update documentation and tests for new events

## Testing
- `ruff check app`
- `pytest -q`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688520f1eb8c832a9f948df95f5450fd