### PR TITLE
Add PAYWALL_ENABLED flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -82,3 +82,4 @@ S3_PUBLIC_URL=http://localhost:9000
 FREE_MONTHLY_LIMIT=5
 # Number of free photos for Telegram bot per month
 FREE_PHOTO_LIMIT=5
+PAYWALL_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ agronom-bot/
    В файл `.env` добавьте переменные:
 
    - `BOT_TOKEN_DEV=ваш_токен_бота`
-   - `PARTNER_LINK_BASE=https://agrostore.ru/agronom`
+  - `PARTNER_LINK_BASE=https://agrostore.ru/agronom`
+  - `PAYWALL_ENABLED=true`  # включить показ paywall
 
    ```bash
    npm install --prefix bot

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
 
     hmac_secret: str = "test-hmac-secret"
     free_monthly_limit: int = 5
+    paywall_enabled: bool = Field(True, alias="PAYWALL_ENABLED")
 
     api_key: str = "test-api-key"
 

--- a/app/main.py
+++ b/app/main.py
@@ -54,6 +54,7 @@ app = FastAPI(
 HMAC_SECRET = settings.hmac_secret
 # Количество бесплатных запросов в месяц
 FREE_MONTHLY_LIMIT = settings.free_monthly_limit
+PAYWALL_ENABLED = settings.paywall_enabled
 
 # -------------------------------
 # Pydantic Schemas (по OpenAPI)
@@ -232,7 +233,11 @@ async def diagnose(
             {"uid": user_id},
         ).scalar()
         now_utc = datetime.now(timezone.utc)
-        if used > FREE_MONTHLY_LIMIT and (not pro or pro < now_utc):
+        if (
+            PAYWALL_ENABLED
+            and used > FREE_MONTHLY_LIMIT
+            and (not pro or pro < now_utc)
+        ):
             return JSONResponse(
                 status_code=402,
                 content={"error": "limit_reached", "limit": FREE_MONTHLY_LIMIT},

--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -2,6 +2,9 @@ const API_BASE = process.env.API_BASE_URL || 'http://localhost:8000';
 const API_KEY = process.env.API_KEY || 'test-api-key';
 const API_VER = process.env.API_VER || 'v1';
 const crypto = require('node:crypto');
+function paywallEnabled() {
+  return process.env.PAYWALL_ENABLED !== 'false';
+}
 
 function getLimit() {
   return parseInt(process.env.FREE_PHOTO_LIMIT || '5', 10);
@@ -20,16 +23,21 @@ async function logEvent(pool, userId, ev) {
 }
 
 function sendPaywall(ctx, pool) {
+  if (!paywallEnabled()) {
+    return;
+  }
   if (ctx.from) {
     logEvent(pool, ctx.from.id, 'paywall_shown');
   }
   const limit = getLimit();
   return ctx.reply(`Бесплатный лимит ${limit} фото/мес исчерпан`, {
     reply_markup: {
-      inline_keyboard: [[
-        { text: 'Купить PRO (199 ₽/мес)', url: 'https://t.me/YourBot?start=paywall' },
-        { text: 'Подробнее', url: 'https://t.me/YourBot?start=faq' },
-      ]],
+      inline_keyboard: [
+        [
+          { text: 'Купить PRO (199 ₽/мес)', url: 'https://t.me/YourBot?start=paywall' },
+          { text: 'Подробнее', url: 'https://t.me/YourBot?start=faq' },
+        ],
+      ],
     },
   });
 }

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -158,3 +158,12 @@ test('startHandler logs paywall clicks', async () => {
     ['INSERT INTO events (user_id, event) VALUES ($1, $2)', [9, 'paywall_click_faq']],
   ]);
 });
+
+test('paywall disabled does not reply', async () => {
+  process.env.PAYWALL_ENABLED = 'false';
+  const replies = [];
+  const ctx = { reply: async (msg, opts) => replies.push({ msg, opts }) };
+  await subscribeHandler(ctx);
+  assert.equal(replies.length, 0);
+  delete process.env.PAYWALL_ENABLED;
+});

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -485,3 +485,22 @@ def test_sixth_diagnose_call_returns_402(client):
     assert sixth.status_code == 402
     data = sixth.json()
     assert data.get("error") == "limit_reached"
+
+
+def test_paywall_disabled_returns_200(monkeypatch, client):
+    monkeypatch.setattr("app.main.FREE_MONTHLY_LIMIT", 1)
+    monkeypatch.setattr("app.main.PAYWALL_ENABLED", False)
+
+    first = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
+    )
+    assert second.status_code == 200


### PR DESCRIPTION
## Summary
- add PAYWALL_ENABLED to settings and env template
- use PAYWALL_ENABLED in API and bot handlers
- document flag in README
- cover paywall flag with tests

## Testing
- `ruff check app/ bot/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852cf1b634832a81c84cba28a5f6ac