### PR TITLE
fix: set SQLite app.db as default DSN

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -31,7 +31,8 @@ POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 
 # SQLAlchemy строка подключения (используется Alembic)
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/your_db
+# Перед запуском миграций укажите эту переменную
+DATABASE_URL=sqlite:///./app.db
 REDIS_URL=redis://localhost:6379
 
 # ==========================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: sqlite:///./test.db
+      DATABASE_URL: sqlite:///./app.db
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ pytest_cache/
 # DB (если SQLite используется локально)
 db.sqlite3
 app.db
-test.db
 
 # Exported OpenAPI clients
 client/

--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ agronom-bot/
 
 **Потребуется Node.js 18+** — используется для Telegram‑бота и тестов.
 
-3. Установите зависимости командой `./.codex/setup.sh` и дополнительные пакеты для тестов из `requirements-dev.txt`. Команду `pip install -r ./requirements-dev.txt` запускайте **из корня репозитория**. Перед запуском приложения обязательно примените миграции:
+3. Установите зависимости командой `./.codex/setup.sh` и дополнительные пакеты для тестов из `requirements-dev.txt`. Команду `pip install -r ./requirements-dev.txt` запускайте **из корня репозитория**. Перед запуском приложения обязательно задайте `DATABASE_URL` и примените миграции:
 
    ```bash
    ./.codex/setup.sh
    pip install -r ./requirements-dev.txt
+   export DATABASE_URL=sqlite:///./app.db  # или другая строка подключения
    alembic upgrade head
    ```
    Если пропустить этот шаг и таблица `protocols` не будет создана, функция
@@ -179,7 +180,7 @@ agronom-bot/
    ```
 
    При отсутствии переменной окружения `DATABASE_URL` тесты используют
-   SQLite файл `./test.db`.
+   SQLite файл `./app.db`.
 
 7. Проверьте спецификацию OpenAPI линтером Spectral:
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -20,7 +20,7 @@ target_metadata = Base.metadata
 url = (
     os.getenv("DATABASE_URL")
     or os.getenv("DB_URL")
-    or "sqlite:///./test.db"
+    or "sqlite:///./app.db"
 )
 
 config = context.config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import subprocess
 import pytest
 
 # Ensure tests run against SQLite when DATABASE_URL is not defined
-os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./app.db")
 
 from fastapi.testclient import TestClient
 from app.main import app


### PR DESCRIPTION
## Summary
- default to `sqlite:///./app.db` in Alembic env and tests
- use the same DSN in CI and docs
- add note about setting `DATABASE_URL` before migrations
- cleanup unused `test.db` ignores

## Testing
- `ruff check app tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885337349c4832aa13111a196c602ab