### PR TITLE
[chore] telegram bot DB env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -33,6 +33,7 @@ POSTGRES_PORT=5432
 # SQLAlchemy строка подключения (используется Alembic)
 # Перед запуском миграций укажите эту переменную
 DATABASE_URL=sqlite:///./app.db
+BOT_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
 REDIS_URL=redis://localhost:6379
 
 # ==========================

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ agronom-bot/
    POSTGRES_HOST=localhost
    POSTGRES_PORT=5432
    DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
+   BOT_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
 
    S3_BUCKET=agronom
    S3_ENDPOINT=http://localhost:9000
@@ -160,8 +161,11 @@ agronom-bot/
    В файл `.env` добавьте переменные:
 
    - `BOT_TOKEN_DEV=ваш_токен_бота`
-  - `PARTNER_LINK_BASE=https://agrostore.ru/agronom`
-  - `PAYWALL_ENABLED=true`  # включить показ paywall
+   - `PARTNER_LINK_BASE=https://agrostore.ru/agronom`
+   - `PAYWALL_ENABLED=true`  # включить показ paywall
+   - `BOT_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom`  # строка подключения для бота
+
+  Бот подключается к PostgreSQL по DSN из `BOT_DATABASE_URL`.
 
    ```bash
    npm install --prefix bot

--- a/bot/index.js
+++ b/bot/index.js
@@ -9,7 +9,10 @@ if (!token) {
   throw new Error('BOT_TOKEN_DEV not set');
 }
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new Pool({
+  connectionString:
+    process.env.BOT_DATABASE_URL || process.env.DATABASE_URL,
+});
 const bot = new Telegraf(token);
 
 bot.start((ctx) => startHandler(ctx, pool));


### PR DESCRIPTION
## Summary
- support `BOT_DATABASE_URL` in Telegram bot
- document the new variable in README and `.env.template`

## Testing
- `pytest -q`
- `ruff check app/`
- `npm install --prefix bot`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_6885370cd438832a82b1b1698a4cbca0