### PR TITLE
Refactor storage client init

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,7 +8,17 @@ from moto import mock_aws
 from fastapi import HTTPException
 from app.services import storage
 from app.config import Settings
-from app.services.storage import upload_photo, get_public_url
+from app.services.storage import upload_photo, get_public_url, get_client
+
+
+@mock_aws
+def test_lazy_client_initialization():
+    storage.init_storage(Settings(_env_file=None))
+    assert storage._client is None
+    first = get_client()
+    assert first is storage._client
+    again = get_client()
+    assert again is first
 
 
 @mock_aws


### PR DESCRIPTION
## Summary
- lazily create boto3 S3 client through new `get_client()`
- reset cached S3 client in `init_storage`
- use `get_client()` in `upload_photo` and `get_public_url`
- test lazy initialization of the S3 client

## Testing
- `ruff check app/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a00e6afc832a88c1f64fc3b64999