### PR TITLE
Add payments table fields

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -466,8 +466,9 @@ async def payments_webhook(
         payment = Payment(
             user_id=1,
             amount=body.amount,
-            source="sbp",
+            provider="sbp",
             status=body.status,
+            currency=body.currency,
         )
         db.add(payment)
         db.commit()

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,6 +1,8 @@
-from sqlalchemy import Column, Integer, String, DateTime, Enum
-from app.models.base import Base
 from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, Enum, Integer, String
+
+from app.models.base import Base
 
 
 class Payment(Base):
@@ -9,9 +11,13 @@ class Payment(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, nullable=False)
     amount = Column(Integer)
-    source = Column(String)
+    currency = Column(String)
+    provider = Column(String)
+    external_id = Column(String)
+    prolong_months = Column(Integer)
     status = Column(
         Enum("success", "fail", "cancel", "bank_error", name="payment_status"),
         nullable=False,
     )
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -15,7 +15,7 @@ id PK, user_id FK, file_id TEXT, file_unique_id TEXT, width INT, height INT, fil
 3.3 protocols
 Без изменений
 3.4 payments
-id PK, user_id FK, amount INT, source TEXT, status payment_status, created_at TIMESTAMP
+id PK, user_id FK, amount INT, currency TEXT, status payment_status, created_at TIMESTAMP, updated_at TIMESTAMP, provider TEXT, external_id TEXT, prolong_months INT
 3.5 partner_orders
 id PK, user_id FK, order_id TEXT, protocol_id INT, price_kopeks INT, signature TEXT, created_at TIMESTAMP, status order_status
 3.6 photo_quota (NEW)

--- a/migrations/versions/1848f456e8dd_update_payments_table.py
+++ b/migrations/versions/1848f456e8dd_update_payments_table.py
@@ -1,0 +1,39 @@
+"""update payments table
+
+Revision ID: 1848f456e8dd
+Revises: f68b39e27e92
+Create Date: 2025-07-27 05:34:15.363485
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1848f456e8dd'
+down_revision = 'f68b39e27e92'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    """Add new fields to payments table and rename source to provider."""
+    op.add_column("payments", sa.Column("provider", sa.String))
+    op.execute("UPDATE payments SET provider = source")
+    op.drop_column("payments", "source")
+
+    op.add_column("payments", sa.Column("currency", sa.String))
+    op.add_column("payments", sa.Column("updated_at", sa.DateTime))
+    op.add_column("payments", sa.Column("external_id", sa.String))
+    op.add_column("payments", sa.Column("prolong_months", sa.Integer))
+
+def downgrade() -> None:
+    """Revert payments table changes."""
+    op.drop_column("payments", "prolong_months")
+    op.drop_column("payments", "external_id")
+    op.drop_column("payments", "updated_at")
+    op.drop_column("payments", "currency")
+
+    op.add_column("payments", sa.Column("source", sa.String))
+    op.execute("UPDATE payments SET source = provider")
+    op.drop_column("payments", "provider")


### PR DESCRIPTION
## Summary
- add provider and other fields to `Payment` model
- migrate payments table to new schema
- document new table structure

## Testing
- `ruff check app/ migrations/versions/1848f456e8dd_update_payments_table.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b9c1fb3c832a990a0339efceef70