### PR TITLE
Update SBP webhook

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -133,19 +133,16 @@ components:
 
     PaymentWebhook:
       type: object
-      required: [payment_id, amount, currency, status, signature]
+      required: [external_id, status, paid_at, signature]
       properties:
-        payment_id:
+        external_id:
           type: string
-        amount:
-          type: integer
-          description: value in kopeks
-        currency:
-          type: string
-          example: RUB
         status:
           type: string
           enum: [success, fail, cancel, bank_error]
+        paid_at:
+          type: string
+          format: date-time
         signature:
           type: string
           description: HMAC-SHA256 of payload


### PR DESCRIPTION
## Summary
- accept external_id, paid_at and status in SBP webhook
- update payment status and prolong PRO subscription
- log payment events
- verify webhook signature when SECURE_WEBHOOK is enabled
- test webhook success and signature failure

## Testing
- `ruff check app/ tests/test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c4de0198832a8ad15d7bec15597a