### PR TITLE
[feature] photo status failed enum

### DIFF
--- a/app/models/photo.py
+++ b/app/models/photo.py
@@ -17,7 +17,7 @@ class Photo(Base):
     disease = Column(String)
     confidence = Column(Float)
     status = Column(
-        Enum("pending", "ok", "retrying", name="photo_status"),
+        Enum("pending", "ok", "retrying", "failed", name="photo_status"),
         nullable=False,
         server_default="pending",
     )

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -25,9 +25,9 @@ user_id PK, month CHAR(7) PK, used INT, updated_at TIMESTAMP
 3.8 events (NEW)
 id PK, user_id INT, event TEXT, ts TIMESTAMP
 4 · Enum Definitions
-CREATE TYPE payment_status AS ENUM ('success','fail','cancel','bank_error');CREATE TYPE photo_status   AS ENUM ('pending','ok','retrying');CREATE TYPE order_status   AS ENUM ('new','processed','cancelled');CREATE TYPE error_code     AS ENUM ('NO_LEAF', 'LIMIT_EXCEEDED', 'GPT_TIMEOUT', 'BAD_REQUEST', 'UNAUTHORIZED');
+CREATE TYPE payment_status AS ENUM ('success','fail','cancel','bank_error');CREATE TYPE photo_status   AS ENUM ('pending','ok','retrying','failed');CREATE TYPE order_status   AS ENUM ('new','processed','cancelled');CREATE TYPE error_code     AS ENUM ('NO_LEAF', 'LIMIT_EXCEEDED', 'GPT_TIMEOUT', 'BAD_REQUEST', 'UNAUTHORIZED');
 5 · Data Lifecycle
-graph TDPENDING[photos.status=pending] -->|predict| OK[status=ok]PENDING -->|retry| RETRY[status=retrying]RETRY -->|predict| OKPhotos auto-delete from S3 after 90d. DB rows soft-deleted 30d later. Quota resets monthly.
+graph TDPENDING[photos.status=pending] -->|predict| OK[status=ok]PENDING -->|retry| RETRY[status=retrying]RETRY -->|error| FAILED[status=failed]RETRY -->|predict| OKPhotos auto-delete from S3 after 90d. DB rows soft-deleted 30d later. Quota resets monthly.
 6 · API ↔ DB Mapping (extract)
 /v1/ai/diagnose → insert photos/v1/limits → read photo_quota + count from photos/v1/payments/sbp/webhook → insert payments/v1/partner/orders → insert partner_orders (with signature)
 

--- a/migrations/versions/b3077f721ed4_add_failed_photo_status_and_index.py
+++ b/migrations/versions/b3077f721ed4_add_failed_photo_status_and_index.py
@@ -1,0 +1,35 @@
+"""add failed photo status and index
+
+Revision ID: b3077f721ed4
+Revises: 48faa6fea9c8
+Create Date: 2025-07-27 09:20:55.388403
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = 'b3077f721ed4'
+down_revision = '48faa6fea9c8'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    """Add 'failed' state to photo_status enum and index on photos.status."""
+
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute("ALTER TYPE photo_status ADD VALUE IF NOT EXISTS 'failed'")
+
+    op.create_index("idx_photo_status", "photos", ["status"], unique=False)
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    op.drop_index("idx_photo_status", table_name="photos")
+
+    if conn.dialect.name == "postgresql":
+        op.execute(
+            "DELETE FROM pg_enum WHERE enumlabel='failed' AND enumtypid = (SELECT oid FROM pg_type WHERE typname='photo_status')"
+        )


### PR DESCRIPTION
## Summary
- add `failed` state to photo_status enum
- add index on photos.status
- reflect enum change in docs

## Testing
- `ruff check app/`
- `npx -y @stoplight/spectral-cli lint openapi/openapi.yaml`
- `pytest -q`
- `alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_6885ecb9befc832ab73c3a42773b2aec