### PR TITLE
[feature] pending diagnosis retry

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
-const { photoHandler, messageHandler, startHandler, subscribeHandler, buyProHandler } = require('./handlers');
+const { photoHandler, messageHandler, startHandler, subscribeHandler, buyProHandler, retryHandler } = require('./handlers');
 
 const token = process.env.BOT_TOKEN_DEV;
 if (!token) {
@@ -35,6 +35,18 @@ bot.action(/^proto\|/, (ctx) => {
 bot.action('ask_expert', (ctx) => {
   ctx.answerCbQuery();
   return ctx.reply('Свяжитесь с экспертом для уточнения протокола.');
+});
+
+bot.command('retry', (ctx) => {
+  const [, id] = ctx.message.text.split(' ');
+  if (id) return retryHandler(ctx, id);
+  return ctx.reply('Укажите ID фото после команды /retry');
+});
+
+bot.action(/^retry\|/, (ctx) => {
+  const [, id] = ctx.callbackQuery.data.split('|');
+  ctx.answerCbQuery();
+  return retryHandler(ctx, id);
 });
 
 bot.action('buy_pro', (ctx) => buyProHandler(ctx, pool));


### PR DESCRIPTION
## Summary
- add pending status handling in `photoHandler`
- implement `retryHandler` and expose via command and button
- support /retry command and inline callback in bot
- test pending flow and retry logic

## Testing
- `npm test --prefix bot`
- `ruff check app/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f5b5eb00832aab2d4c5625ccaea7