### PR TITLE
[feature] add failed photo status enum

### DIFF
--- a/app/models/photo.py
+++ b/app/models/photo.py
@@ -17,7 +17,7 @@ class Photo(Base):
     disease = Column(String)
     confidence = Column(Float)
     status = Column(
-        Enum("pending", "ok", "retrying", name="photo_status"),
+        Enum("pending", "ok", "retrying", "failed", name="photo_status"),
         nullable=False,
         server_default="pending",
     )

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -25,9 +25,9 @@ user_id PK, month CHAR(7) PK, used INT, updated_at TIMESTAMP
 3.8 events (NEW)
 id PK, user_id INT, event TEXT, ts TIMESTAMP
 4 · Enum Definitions
-CREATE TYPE payment_status AS ENUM ('success','fail','cancel','bank_error');CREATE TYPE photo_status   AS ENUM ('pending','ok','retrying');CREATE TYPE order_status   AS ENUM ('new','processed','cancelled');CREATE TYPE error_code     AS ENUM ('NO_LEAF', 'LIMIT_EXCEEDED', 'GPT_TIMEOUT', 'BAD_REQUEST', 'UNAUTHORIZED');
+CREATE TYPE payment_status AS ENUM ('success','fail','cancel','bank_error');CREATE TYPE photo_status   AS ENUM ('pending','ok','retrying','failed');CREATE TYPE order_status   AS ENUM ('new','processed','cancelled');CREATE TYPE error_code     AS ENUM ('NO_LEAF', 'LIMIT_EXCEEDED', 'GPT_TIMEOUT', 'BAD_REQUEST', 'UNAUTHORIZED');
 5 · Data Lifecycle
-graph TDPENDING[photos.status=pending] -->|predict| OK[status=ok]PENDING -->|retry| RETRY[status=retrying]RETRY -->|predict| OKPhotos auto-delete from S3 after 90d. DB rows soft-deleted 30d later. Quota resets monthly.
+graph TDPENDING[photos.status=pending] -->|predict| OK[status=ok]PENDING -->|retry| RETRY[status=retrying]RETRY -->|fail| FAILED[status=failed]RETRY -->|predict| OKPhotos auto-delete from S3 after 90d. DB rows soft-deleted 30d later. Quota resets monthly.
 6 · API ↔ DB Mapping (extract)
 /v1/ai/diagnose → insert photos/v1/limits → read photo_quota + count from photos/v1/payments/sbp/webhook → insert payments/v1/partner/orders → insert partner_orders (with signature)
 

--- a/migrations/versions/f72b70304116_add_failed_photo_status_and_index.py
+++ b/migrations/versions/f72b70304116_add_failed_photo_status_and_index.py
@@ -1,0 +1,37 @@
+"""add failed photo status and index
+
+Revision ID: f72b70304116
+Revises: 48faa6fea9c8
+Create Date: 2025-07-27 10:07:49.392139
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = 'f72b70304116'
+down_revision = '48faa6fea9c8'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    """Add 'failed' value to photo_status enum and index photos.status."""
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute(
+            "ALTER TYPE photo_status ADD VALUE IF NOT EXISTS 'failed'"
+        )
+    op.create_index("ix_photos_status", "photos", ["status"], unique=False)
+
+def downgrade() -> None:
+    """Remove index and 'failed' value from photo_status enum."""
+    op.drop_index("ix_photos_status", table_name="photos")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute(
+            "DELETE FROM pg_enum WHERE enumlabel='failed' AND enumtypid = "
+            "(SELECT oid FROM pg_type WHERE typname='photo_status')"
+        )
+

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -178,7 +178,7 @@ components:
       properties:
         status:
           type: string
-          enum: [pending, ok, retrying]
+          enum: [pending, ok, retrying, failed]
         updated_at:
           type: string
           format: date-time

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -277,6 +277,24 @@ def test_photo_status_completed(client):
     assert body["protocol"] is not None
 
 
+def test_photo_status_failed(client):
+    """Photo with failed status returns minimal fields."""
+    from app.db import SessionLocal
+    from app.models import Photo
+
+    with SessionLocal() as session:
+        photo = Photo(user_id=1, file_id="test.jpg", status="failed")
+        session.add(photo)
+        session.commit()
+        pid = photo.id
+
+    resp = client.get(f"/v1/photos/{pid}", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert "updated_at" in data
+
+
 def test_create_payment(client):
     payload = {"user_id": 1, "plan": "pro", "months": 1}
     resp = client.post("/v1/payments/create", headers=HEADERS, json=payload)


### PR DESCRIPTION
## Summary
- add `failed` status in photos model
- create alembic migration to extend enum and add index on `photos.status`
- update docs and OpenAPI spec
- test new status

## Testing
- `ruff check app/ tests/`
- `npx -y @stoplight/spectral lint -r .spectral.yaml openapi/openapi.yaml`
- `alembic upgrade head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f9d32fc4832aa2dc9553964c01c7