### PR TITLE
[fix] use canonical photo status endpoint

### DIFF
--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -192,7 +192,7 @@ function subscribeHandler(ctx, pool) {
 
 async function retryHandler(ctx, photoId) {
   try {
-    const resp = await fetch(`${API_BASE}/v1/photos/${photoId}/status`, {
+    const resp = await fetch(`${API_BASE}/v1/photos/${photoId}`, {
       headers: { 'X-API-Key': API_KEY, 'X-API-Ver': API_VER },
     });
     if (!resp.ok) {

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -249,7 +249,7 @@ test('retryHandler returns result', { concurrency: false }, async () => {
   const replies = [];
   const ctx = { from: { id: 1 }, reply: async (msg, opts) => replies.push({ msg, opts }) };
   await withMockFetch({
-    'http://localhost:8000/v1/photos/42/status': {
+    'http://localhost:8000/v1/photos/42': {
       json: async () => ({
         status: 'ok',
         crop: 'apple',


### PR DESCRIPTION
## Summary
- update retryHandler to fetch `/v1/photos/{photo_id}`
- adjust bot tests for the new path

## Testing
- `ruff check app/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886195954d0832a840455da19c74908