### PR TITLE
[fix] pending response for diagnosis failures

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -407,8 +407,10 @@ async def diagnose(
         db.add(photo)
         db.commit()
         if status != "ok":
-            err = ErrorResponse(code="GPT_TIMEOUT", message="GPT timeout")
-            return JSONResponse(status_code=502, content=err.model_dump())
+            return JSONResponse(
+                status_code=202,
+                content={"id": photo.id, "status": "pending"},
+            )
 
     proto = find_protocol(crop, disease)
     if proto:

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -235,7 +235,7 @@ test('photoHandler pending reply', { concurrency: false }, async () => {
   };
   await withMockFetch({
     'http://file': { arrayBuffer: async () => Buffer.from('x') },
-    default: { json: async () => ({ status: 'pending', id: 42 }) },
+    default: { status: 202, json: async () => ({ status: 'pending', id: 42 }) },
   }, async () => {
     await photoHandler(pool, ctx);
   });

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Agronom Bot Internal API
-  version: 1.7.0
+  version: 1.8.0
   description: |
     Telegram-бот «Карманный агроном» — API v1.4.0.
     Fixes: +signature, +UNAUTHORIZED, +monthly limits, +X-API-Ver usage, +multipart required, clarified dosage units.
@@ -189,6 +189,17 @@ components:
         protocol:
           $ref: '#/components/schemas/ProtocolResponse'
 
+    DiagnoseQueuedResponse:
+      type: object
+      required: [id, status]
+      properties:
+        id:
+          type: integer
+          example: 1
+        status:
+          type: string
+          example: pending
+
     ErrorResponse:
       type: object
       required: [code, message]
@@ -240,6 +251,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DiagnoseResponse'
+        '202':
+          description: Image queued for processing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiagnoseQueuedResponse'
         '400':
           description: Bad image / bad request
           content:
@@ -252,12 +269,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LimitReached'
-        '502':
-          description: GPT timeout
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Unexpected internal error
           content:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -203,9 +203,10 @@ def test_diagnose_gpt_timeout(monkeypatch, client):
         headers=HEADERS,
         json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
     )
-    assert resp.status_code == 502
+    assert resp.status_code in {200, 202}
     data = resp.json()
-    assert data["code"] == "GPT_TIMEOUT"
+    assert data["status"] == "pending"
+    assert "id" in data
 
     from app.db import SessionLocal
     from app.models import Photo


### PR DESCRIPTION
## Summary
- return 202 with `{id,status}` when GPT diagnosis fails
- document new response in OpenAPI
- update tests and bot handlers for the new payload

## Testing
- `ruff check app/`
- `pytest -q`
- `npm test --silent --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_68861c035194832abc9cb5fb07f9ea66