### PR TITLE
Update API version

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Agronom Bot Internal API",
-    version="1.5.0",
+    version="1.7.0",
     lifespan=lifespan,
 )
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Agronom Bot Internal API
-  version: 1.8.0
+  version: 1.7.0
   description: |
     Telegram-бот «Карманный агроном» — API v1.4.0.
     Fixes: +signature, +UNAUTHORIZED, +monthly limits, +X-API-Ver usage, +multipart required, clarified dosage units.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,24 @@
+import re
+import yaml
+from app.main import app
+
+def get_readme_version() -> str:
+    with open("README.md", encoding="utf-8") as f:
+        m = re.search(r"Версия API: \*\*v([0-9.]+)\*\*", f.read())
+    assert m, "Version not found in README"
+    return m.group(1)
+
+
+def get_openapi_version() -> str:
+    with open("openapi/openapi.yaml", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+    return str(spec["info"]["version"])
+
+
+def test_readme_matches_openapi():
+    assert get_readme_version() == get_openapi_version()
+
+
+def test_app_version_matches_openapi():
+    assert app.version == get_openapi_version()
+


### PR DESCRIPTION
## Summary
- sync API version constants across main, README and OpenAPI files
- add test to ensure README and OpenAPI version match

## Testing
- `ruff check app/ tests/test_version.py`
- `pytest -q`
- `npx -y @stoplight/spectral-cli lint openapi/openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68861d80a018832abc47412ac8ef0fdc