### PR TITLE
Implement JS GPT stub for retry worker

### DIFF
--- a/worker/gpt_stub.js
+++ b/worker/gpt_stub.js
@@ -1,0 +1,9 @@
+async function callGptVisionStub(_path) {
+  return {
+    crop: 'apple',
+    disease: 'powdery_mildew',
+    confidence: 0.92,
+  };
+}
+
+module.exports = { callGptVisionStub };


### PR DESCRIPTION
## Summary
- add a JS implementation of `call_gpt_vision_stub`
- make `retry_diagnosis` worker call the stub asynchronously

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68862d5a7224832ab800ad97564896bf