### PR TITLE
Add photos history endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -118,6 +118,32 @@ components:
               format: date-time
               example: "2025-07-20T12:34:56Z"
 
+    PhotoHistoryItem:
+      type: object
+      required: [photo_id, ts, crop, disease, status, confidence, thumb_url]
+      properties:
+        photo_id:
+          type: integer
+          example: 1
+        ts:
+          type: string
+          format: date-time
+        crop:
+          type: string
+          example: apple
+        disease:
+          type: string
+          example: scab
+        status:
+          type: string
+          enum: [pending, ok, retrying, failed]
+        confidence:
+          type: number
+          format: float
+        thumb_url:
+          type: string
+          format: uri
+
     ListPhotosResponse:
       type: object
       required: [items]
@@ -313,6 +339,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /v1/photos/history:
+    get:
+      summary: Photo history (offset)
+      operationId: listPhotosHistory
+      description: Return past photos ordered by ts DESC.
+      tags: [photos]
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+            maximum: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: user_id
+          in: query
+          schema:
+            type: integer
+          description: User ID (stub)
+      responses:
+        '200':
+          description: List of history items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PhotoHistoryItem'
 
   /v1/photos/{photo_id}:
     get:

--- a/tests/fastify_history.test.js
+++ b/tests/fastify_history.test.js
@@ -1,0 +1,25 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { app, pool } = require('../fastify');
+
+test('history uses limit and offset', async () => {
+  let received;
+  pool.query = async (sql, params) => {
+    received = params;
+    return { rows: [] };
+  };
+  const res = await app.inject('/v1/photos/history?limit=5&offset=2');
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(received, [1, 5, 2]);
+});
+
+test('history caps limit at 50', async () => {
+  let received;
+  pool.query = async (sql, params) => {
+    received = params;
+    return { rows: [] };
+  };
+  const res = await app.inject('/v1/photos/history?limit=99');
+  assert.equal(res.statusCode, 200);
+  assert.equal(received[1], 50);
+});


### PR DESCRIPTION
## Summary
- implement fastify GET /v1/photos/history
- export fastify app for tests
- document history endpoint in OpenAPI
- add unit tests for limit/offset behavior

## Testing
- `ruff check app/`
- `pytest -q`
- `node tests/fastify_history.test.js` *(fails: Cannot find module 'fastify')*

------
https://chatgpt.com/codex/tasks/task_e_688636bb98d4832aa2cfb3340be4a209