### PR TITLE
[feature] history pagination command

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,7 +1,15 @@
 require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
-const { photoHandler, messageHandler, startHandler, subscribeHandler, buyProHandler, retryHandler } = require('./handlers');
+const {
+  photoHandler,
+  messageHandler,
+  startHandler,
+  subscribeHandler,
+  buyProHandler,
+  retryHandler,
+  historyHandler,
+} = require('./handlers');
 
 const token = process.env.BOT_TOKEN_DEV;
 if (!token) {
@@ -17,6 +25,8 @@ const bot = new Telegraf(token);
 bot.start((ctx) => startHandler(ctx, pool));
 
 bot.command('subscribe', (ctx) => subscribeHandler(ctx, pool));
+
+bot.command('history', (ctx) => historyHandler(ctx, 0));
 
 bot.on('photo', (ctx) => photoHandler(pool, ctx));
 
@@ -44,6 +54,19 @@ bot.command('retry', (ctx) => {
 });
 
 bot.action(/^retry\|/, (ctx) => {
+  const [, id] = ctx.callbackQuery.data.split('|');
+  ctx.answerCbQuery();
+  return retryHandler(ctx, id);
+});
+
+bot.action(/^history\|/, (ctx) => {
+  const [, off] = ctx.callbackQuery.data.split('|');
+  const offset = Math.max(parseInt(off, 10) || 0, 0);
+  ctx.answerCbQuery();
+  return historyHandler(ctx, offset);
+});
+
+bot.action(/^info\|/, (ctx) => {
   const [, id] = ctx.callbackQuery.data.split('|');
   ctx.answerCbQuery();
   return retryHandler(ctx, id);


### PR DESCRIPTION
## Summary
- add historyHandler to load `/v1/photos/history`
- register /history command with callbacks for paging and info
- test pagination logic in handlers.test.js

## Testing
- `npm test --prefix bot`
- `ruff check app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886391699a8832a8e1a07c85723bad0