### PR TITLE
feat(bot): command menu for Telegram

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -168,6 +168,13 @@ test('startHandler logs paywall clicks', { concurrency: false }, async () => {
   ]);
 });
 
+test('startHandler replies with onboarding text', { concurrency: false }, async () => {
+  let msg = '';
+  const ctx = { reply: async (m) => { msg = m; }, startPayload: undefined, from: { id: 1 } };
+  await startHandler(ctx, { query: async () => {} });
+  assert.equal(msg, 'Отправьте фото листа для диагностики');
+});
+
 test('buyProHandler returns payment link', { concurrency: false }, async () => {
   const replies = [];
   const ctx = { from: { id: 1 }, answerCbQuery: () => {}, reply: async (msg, opts) => replies.push({ msg, opts }) };

--- a/bot/index.js
+++ b/bot/index.js
@@ -22,7 +22,17 @@ const pool = new Pool({
 });
 const bot = new Telegraf(token);
 
-bot.start((ctx) => startHandler(ctx, pool));
+bot.telegram.setMyCommands([
+  { command: 'start', description: 'Начать работу' },
+  { command: 'help', description: 'Помощь' },
+  { command: 'history', description: 'История запросов' },
+  { command: 'subscribe', description: 'Купить PRO' },
+]);
+
+bot.start(async (ctx) => {
+  await startHandler(ctx, pool);
+  await bot.telegram.setChatMenuButton(ctx.chat.id, { type: 'commands' });
+});
 
 bot.command('subscribe', (ctx) => subscribeHandler(ctx, pool));
 


### PR DESCRIPTION
## Summary
- expose `/start`, `/help`, `/history` and `/subscribe` in bot command list
- open command menu after running `/start`
- test onboarding message

## Testing
- `npm --prefix bot test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68863a712500832ab236ac2efb821a4a