### PR TITLE
[test] ensure fetch mocks release streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "worker": "node worker/usage_reset.js"
+    "worker": "node worker/usage_reset.js",
+    "test": "node --test bot/handlers.test.js"
   },
   "dependencies": {
     "dotenv": "^17.2.1",


### PR DESCRIPTION
## Summary
- ensure mocked fetch responses close any provided streams
- run Telegram bot tests via `npm test`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688654279f54832aa3127af569a32c2a