### PR TITLE
[feature] log history open & pages

### DIFF
--- a/bot/handlers.js
+++ b/bot/handlers.js
@@ -212,8 +212,10 @@ function subscribeHandler(ctx, pool) {
 
 async function historyHandler(ctx, offset = 0, pool) {
   if (ctx.from && pool) {
-    const ev = offset === 0 ? 'history_open' : 'history_page';
-    logEvent(pool, ctx.from.id, ev);
+    if (offset === 0) {
+      logEvent(pool, ctx.from.id, 'history_open');
+    }
+    logEvent(pool, ctx.from.id, `history_page_${offset}`);
   }
   const resp = await fetch(
     `${API_BASE}/v1/photos/history?limit=10&offset=${offset}`,

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -312,6 +312,7 @@ test('historyHandler paginates', { concurrency: false }, async () => {
   assert.equal(kb[0][0].callback_data, 'info|1');
   assert.equal(kb[kb.length - 1][1].callback_data, 'history|10');
   assert.equal(events[0][1][1], 'history_open');
+  assert.equal(events[1][1][1], 'history_page_0');
 });
 
 test('historyHandler logs page event', { concurrency: false }, async () => {
@@ -323,7 +324,7 @@ test('historyHandler logs page event', { concurrency: false }, async () => {
   }, async () => {
     await historyHandler(ctx, 10, pool);
   });
-  assert.equal(events[0][1][1], 'history_page');
+  assert.equal(events[0][1][1], 'history_page_10');
 });
 
 test('helpHandler returns link', { concurrency: false }, async () => {


### PR DESCRIPTION
## Summary
- log history_open when showing first history page
- log history_page events with current offset
- update unit tests for new events

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865e9fabbc832aa8264cb6432538c6