### PR TITLE
[refactor] lazy DB init

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,5 +1,6 @@
 import os
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 from app.models import Base
@@ -7,17 +8,14 @@ from app.config import Settings
 
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
-engine = create_engine(DATABASE_URL, future=True)
-SessionLocal = sessionmaker(
-    bind=engine,
-    autoflush=False,
-    autocommit=False,
-    future=True,
-)
+
+# Engine and session factory are created lazily via ``init_db``.
+engine: Engine | None = None
+SessionLocal: sessionmaker | None = None
 
 
 def init_db(cfg: Settings) -> None:
-    """Configure engine and session factory using provided settings."""
+    """Create engine and session factory using provided settings."""
     global engine, SessionLocal
 
     engine = create_engine(cfg.database_url, future=True)
@@ -31,7 +29,3 @@ def init_db(cfg: Settings) -> None:
     if cfg.db_create_all:
         Base.metadata.create_all(engine)
 
-
-# Optionally create tables automatically when DB_CREATE_ALL is set
-if os.getenv("DB_CREATE_ALL"):
-    Base.metadata.create_all(engine)

--- a/app/services/protocols.py
+++ b/app/services/protocols.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from sqlalchemy import inspect
 from sqlalchemy.exc import OperationalError
 
-from app.db import SessionLocal
+from app import db
 from app.models import Protocol
 
 # CSV is stored in the repository root
@@ -50,7 +50,7 @@ def import_csv_to_db(path: Path = CSV_PATH, update: bool = False) -> None:
             logging.warning("CSV download failed: %s — using cached file", exc)
 
     # -------- 2. connect to DB -------------------------------------------------
-    session = SessionLocal()
+    session = db.SessionLocal()
 
     # DEBUG ─────────────────────────────────────────────────────────────────────
     engine = session.bind
@@ -100,7 +100,7 @@ def import_csv_to_db(path: Path = CSV_PATH, update: bool = False) -> None:
 # --------------------------------------------------------------------------- #
 @lru_cache(maxsize=None)
 def _cache_protocol(crop: str, disease: str) -> Protocol | None:
-    session = SessionLocal()
+    session = db.SessionLocal()
     proto = (
         session.query(Protocol)
         .filter(Protocol.crop == crop, Protocol.disease == disease)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,14 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///./app.db")
 
 from fastapi.testclient import TestClient
 from app.main import app
+from app.config import Settings
+from app.db import init_db
 
 @pytest.fixture(scope="session", autouse=True)
 def apply_migrations():
     """Apply Alembic migrations before running tests."""
     subprocess.run(["alembic", "upgrade", "head"], check=True)
+    init_db(Settings())
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,10 +1,11 @@
 from app.services.protocols import find_protocol, import_csv_to_db
-from app.db import SessionLocal
 from app.models import Protocol
 
 
 def test_import_csv_no_table():
     """Drop protocols table to verify CSV import recreates it."""
+    from app.db import SessionLocal
+
     with SessionLocal() as session:
         engine = session.bind
 
@@ -17,6 +18,8 @@ def test_import_csv_no_table():
 
 
 def test_find_protocol_found():
+    from app.db import SessionLocal
+
     import_csv_to_db()
     proto = find_protocol("apple", "scab")
     assert proto is not None
@@ -27,6 +30,7 @@ def test_find_protocol_found():
 
 
 def test_find_protocol_missing():
+    from app.db import SessionLocal
     import_csv_to_db()
     proto = find_protocol("apple", "unknown")
     assert proto is None

--- a/tests/test_usage_reset.py
+++ b/tests/test_usage_reset.py
@@ -3,12 +3,13 @@ from zoneinfo import ZoneInfo
 
 from sqlalchemy import text
 
-from app.db import SessionLocal
 from app.models import PhotoUsage
 
 
 def test_usage_reset_cron():
     """Old monthly counters are zeroed by the reset worker."""
+    from app.db import SessionLocal
+
     old_month = "2020-01"
     with SessionLocal() as session:
         session.add(PhotoUsage(user_id=1, month=old_month, used=3))


### PR DESCRIPTION
## Summary
- avoid creating DB engine at import time
- initialize DB engine within FastAPI startup
- update tests for new lazy DB init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886efe0285c832abd7bbf84bf45b815