### PR TITLE
Update rate limit docs

### DIFF
--- a/docs/security_checklist.md
+++ b/docs/security_checklist.md
@@ -4,7 +4,7 @@ Version 1.5 — 26 July 2025
 (v1.3 → v1.4: API rate-limit, business quota FREE_MONTHLY_LIMIT/mo (default 5), signature in body, UNAUTHORIZED error, API versioning X‑API‑Ver, /v1/limits added)
 All controls map to ISO 27001 Annex A. Personal data limited; 152‑ФЗ not triggered.
 1. API Security Controls
-• API requests require `X-API-Key` (header)• Partner API requires `X-Sign` (HMAC-SHA256) and duplicate `signature` field in body• Signature is validated using shared secret from Vault (rotated every 90 days)• All API requests must include `X-API-Ver: v1` (required for version control)• Rate limit: 30 RPS per user• Business quota: FREE_MONTHLY_LIMIT diagnosis requests/month for Free users (default 5), tracked per user_id• Violations return `ErrorResponse` with machine-readable code: `UNAUTHORIZED`, `LIMIT_EXCEEDED`, etc.
+• API requests require `X-API-Key` (header)• Partner API requires `X-Sign` (HMAC-SHA256) and duplicate `signature` field in body• Signature is validated using shared secret from Vault (rotated every 90 days)• All API requests must include `X-API-Ver: v1` (required for version control)• Rate limit: 30 req/min per IP, 120 req/min per user (Pro unlimited)• Business quota: FREE_MONTHLY_LIMIT diagnosis requests/month for Free users (default 5), tracked per user_id• Violations return `ErrorResponse` with machine-readable code: `UNAUTHORIZED`, `LIMIT_EXCEEDED`, etc.
 2. Data Security
 • TLS 1.2+ enforced on all endpoints• Data at rest is AES-256 encrypted (S3, RDS)• GPT API key stored in Vault, rotated monthly• Diagnosis photos auto-deleted after 90 days (S3 lifecycle policy)• GDPR/DSR endpoints: /v1/users/{id}/export, /delete (SLA: 30 days)• Photos linked to user_id for enforcement of quota and GDPR exports
 3. Logging & Monitoring

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -25,11 +25,11 @@ agro-testset-v1/ (S3): 1 000 JPG + CSV-метки + MD5, SHA‑256 маниф�
 • TC‑090: Команда /help показывает справку и доступные команды
 • TC‑100: Пользователь перемещается по меню: старт → история → диагностика
 7. Нагрузочное тестирование
-k6 load_diag.js — 90 RPS, 5 мин; PASS: error < 1 %, latency P95 < 8 c.
+k6 load_diag.js — ~5 000 RPS, 5 мин; PASS: error < 1 %, latency P95 < 8 c.
 8. API integration tests
 Postman collection v1.7 + CI:• Проверка кодов 200/400/401/402/502• Ajv‑валидация схем OpenAPI• Проверка paywall: /limits → 5/5 → diagnose = 402 → paywall
 9. Security checks
-• SSL Labs grade: A• SQL-injection• Проверка HMAC: signature в теле + заголовке• Rate-limiting (30 rps), бизнес-лимит (5/мес)
+• SSL Labs grade: A• SQL-injection• Проверка HMAC: signature в теле + заголовке• Rate-limiting (30 req/min per IP, 120 req/min per user (Pro unlimited)), бизнес-лимит (5/мес)
 10. Schedule & Roles
 (QA-инженер, DevOps, Security, Product Owner — см. Notion / JIRA)
 11. Risk & Mitigation


### PR DESCRIPTION
## Summary
- document new API rate limits in security checklist and test plan
- mention ~5 000 RPS k6 load test target

## Testing
- `ruff check app/`
- `pytest -q` *(fails: CalledProcessError from `alembic upgrade head`)*

------
https://chatgpt.com/codex/tasks/task_e_6886f775fe48832aaf74d421a9b7d647