### PR TITLE
Increase DB pool, add TTL protocol cache

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -11,15 +11,34 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
 # Engine and session factory are created lazily via ``init_db``.
 engine: Engine | None = None
-SessionLocal: sessionmaker | None = None
+_session_factory: sessionmaker | None = None
+
+
+class _SessionWrapper:
+    """Callable proxy returning sessions from the current factory."""
+
+    def __call__(self, *args, **kwargs):
+        if _session_factory is None:
+            raise RuntimeError("Database not initialized")
+        return _session_factory(*args, **kwargs)
+
+
+SessionLocal = _SessionWrapper()
 
 
 def init_db(cfg: Settings) -> None:
     """Create engine and session factory using provided settings."""
-    global engine, SessionLocal
+    global engine, _session_factory
 
-    engine = create_engine(cfg.database_url, future=True)
-    SessionLocal = sessionmaker(
+    engine = create_engine(
+        cfg.database_url,
+        future=True,
+        pool_size=50,
+        max_overflow=0,
+        pool_recycle=30,
+        pool_pre_ping=True,
+    )
+    _session_factory = sessionmaker(
         bind=engine,
         autoflush=False,
         autocommit=False,

--- a/migrations/versions/d6342bc83ba4_merge_heads.py
+++ b/migrations/versions/d6342bc83ba4_merge_heads.py
@@ -1,0 +1,23 @@
+"""merge heads
+
+Revision ID: d6342bc83ba4
+Revises: 632d4e7bf880, 83d28733f0ba
+Create Date: 2025-07-28 04:32:15.162612
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = 'd6342bc83ba4'
+down_revision = ('632d4e7bf880', '83d28733f0ba')
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    pass
+
+def downgrade() -> None:
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ moto[s3]==5.0.12
 pytest-asyncio==1.1.0
 requests==2.32.4
 pydantic-settings==2.2.1
+cachetools==5.3.3


### PR DESCRIPTION
## Что изменено
- увеличен пул подключений к БД (pool_size=50, idle timeout 30 секунд)
- реализован TTL LRU‑кэш для поиска протоколов (10 мин)
- добавлена миграция merge heads для корректной работы `alembic upgrade head`
- обновлены зависимости

## Как проверить
- `pip install -r requirements.txt`
- `alembic upgrade head`
- `pytest -q && ruff check app/`

Связанные issue: #none

------
https://chatgpt.com/codex/tasks/task_e_6886fc937934832ab3d1009c443fa370