### PR TITLE
docs: alerting guide

### DIFF
--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,0 +1,36 @@
+# Alerting Guide – Slack & Telegram
+
+Версия 1.0 — 27 июля 2025 г.
+
+Документ описывает базовую настройку Alertmanager для проекта «Карманный агроном». Алерт отправляется в Slack и Telegram через вебхуки.
+
+## 1. Правила алертов
+
+- **error_rate** > 2 % за последние 5 минут
+- **p95** `/diagnose` > 3 секунд
+- **queue_size_pending** > 100
+
+## 2. Конфигурация Alertmanager
+
+```yaml
+route:
+  receiver: tg_slack
+receivers:
+  - name: tg_slack
+    slack_configs:
+      - api_url: ${SLACK_WEBHOOK_URL}
+        channel: '#alerts'
+    webhook_configs:
+      - url: ${TG_WEBHOOK_URL}
+```
+
+Переменные `SLACK_WEBHOOK_URL` и `TG_WEBHOOK_URL` передаются через окружение.
+
+## 3. Тестовое оповещение
+
+1. Запустите Alertmanager с указанной конфигурацией.
+2. С помощью `amtool` отправьте тестовый алерт:
+   ```bash
+   amtool alert add test_error rate=3
+   ```
+3. Убедитесь, что сообщение появилось в каналах Slack и Telegram.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@
 | [partner_agrostore.md](./partner_agrostore.md) | Интеграция с AgroStore, deep‑link, SLA, подписи |
 | [payment_flow.md](./payment_flow.md) | Платёжный flow и webhook SBP |
 | [retry_logic.md](./retry_logic.md) | Логика повторных попыток и очередь |
+| [alerting.md](./alerting.md) | Настройка Alertmanager и вебхуков |
 
 ---
 

--- a/docs/srs.md
+++ b/docs/srs.md
@@ -148,6 +148,7 @@ expert_response_12h
 Prometheus metrics: diag_latency_seconds, diag_requests_total, gpt_timeout_total, payment_fail_total, queue_size_pending.
 Grafana dashboards: Diag‑health, Payments, System Load.
 Alerts: GPT timeouts > 5 % /5 мин → Slack #alerts.
+Alerts: error_rate > 2 % /5 мин, p95 /diagnose > 3 с, queue_size_pending > 100 → Slack и Telegram.
 queue_monitor.py логирует предупреждение, если фото в статусе pending старше 60 мин.
 11. Security Details
 Webhook SBP: HMAC‑SHA256 header X‑Sign, secret in Vault, rotate 90 дней.


### PR DESCRIPTION
## Summary
- document alerting via Alertmanager and webhooks
- reference new alerting doc from the docs index
- list the new alert in the SRS

## Testing
- `ruff check app/`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68871c8d2f10832aae74fba0ba7f4dab