### PR TITLE
[fix] add missing OpenAPI descriptions

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -403,6 +403,7 @@ paths:
     get:
       summary: Get photo status
       operationId: getPhotoStatus
+      description: Retrieve processing status and details for the specified photo.
       tags: [photos]
       security:
         - ApiKeyAuth: []
@@ -465,6 +466,7 @@ paths:
     post:
       summary: Create SBP payment
       operationId: createPayment
+      description: Initiate a payment via SBP and return a payment link.
       tags: [payments]
       security:
         - ApiKeyAuth: []
@@ -502,6 +504,7 @@ paths:
     get:
       summary: Payment status
       operationId: getPaymentStatus
+      description: Retrieve the current status of a payment.
       tags: [payments]
       security:
         - ApiKeyAuth: []


### PR DESCRIPTION
## Summary
- document photo status endpoint
- document payment endpoints

## Testing
- `npx -y @stoplight/spectral-cli lint -r .spectral.yaml openapi/openapi.yaml`
- `ruff check app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688749b3ac90832a966fbd64858f5205