### PR TITLE
[fix] remove unused migration imports

### DIFF
--- a/migrations/versions/d6342bc83ba4_merge_heads.py
+++ b/migrations/versions/d6342bc83ba4_merge_heads.py
@@ -5,8 +5,8 @@ Revises: 632d4e7bf880, 83d28733f0ba
 Create Date: 2025-07-28 04:32:15.162612
 
 """
-from alembic import op
-import sqlalchemy as sa
+from alembic import op  # noqa: F401
+import sqlalchemy as sa  # noqa: F401
 
 
 

--- a/migrations/versions/f72b70304116_add_failed_photo_status_and_index.py
+++ b/migrations/versions/f72b70304116_add_failed_photo_status_and_index.py
@@ -6,7 +6,7 @@ Create Date: 2025-07-27 10:07:49.392139
 
 """
 from alembic import op
-import sqlalchemy as sa
+import sqlalchemy as sa  # noqa: F401
 
 
 


### PR DESCRIPTION
## Summary
- silence unused imports in migrations by adding `# noqa: F401`
- keep Alembic template imports while passing ruff

## Testing
- `ruff check migrations/versions`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68874e6be534832aadfc46b14973ce63