### PR TITLE
[release] branch protection workflow

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,32 @@
+name: Branch Protection
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release/1.0.0
+
+jobs:
+  protect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set branch protection rules
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          curl -L -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/$OWNER/$REPO/branches/release/1.0.0/protection \
+            -d '{
+              "required_status_checks": {
+                "strict": true,
+                "contexts": ["ci.yml", "perf.yml"]
+              },
+              "required_pull_request_reviews": {
+                "required_approving_review_count": 2
+              },
+              "enforce_admins": true,
+              "restrictions": null
+            }'

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ payment_flow.md — процесс оплаты и webhook SBP
 [privacy_policy.md](docs/privacy_policy.md) — политика конфиденциальности
 
 
+## Release 1.0 maintenance
+
+Bug fixes that must go into the `release/1.0.0` branch should be labeled `release-blocker` so they can be tracked before the final release.
+
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- create branch protection workflow for `release/1.0.0`
- document how to label release fixes

## Testing
- `ruff check app/`
- `pytest -q`

Unable to push release/1.0.0 branch since no remote repository is configured.

------
https://chatgpt.com/codex/tasks/task_e_688763182f04832ab7f949c155ce053c