### PR TITLE
Add migration safety script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,14 @@ agronom-bot/
    pip install -r ./requirements-dev.txt
    npm install
    export DATABASE_URL=sqlite:///./app.db  # или другая строка подключения
-   alembic upgrade head
+   # безопасное применение миграций
+   ./scripts/migrate_safe.sh
+   # посмотреть план без выполнения
+   ./scripts/migrate_safe.sh --dry-run
    ```
    Если пропустить этот шаг и таблица `protocols` не будет создана, функция
    `import_csv_to_db()` просто выдаст предупреждение в лог и посоветует
-   выполнить `alembic upgrade head` или запустить приложение с переменной
+   выполнить `./scripts/migrate_safe.sh` или запустить приложение с переменной
    `DB_CREATE_ALL=1`.
 
 4. Запустите API:

--- a/scripts/migrate_safe.sh
+++ b/scripts/migrate_safe.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Alembic migrations safely.
+# - Checks for long-running DDL queries (>2 seconds) and aborts if any exist.
+# - Supports --dry-run to output the SQL plan without executing.
+
+DB_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/agronom}"
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+    alembic upgrade head --sql
+    exit 0
+fi
+
+# Query pg_stat_activity for active DDL statements running longer than 2 seconds
+CHECK_SQL="SELECT query FROM pg_stat_activity WHERE state = 'active' 
+  AND now() - query_start > interval '2 seconds'
+  AND query ~* '^(alter|create|drop|truncate|reindex|cluster)';"
+
+BLOCKING=$(psql "$DB_URL" -Atc "$CHECK_SQL" || true)
+
+if [[ -n "$BLOCKING" ]]; then
+    echo "Blocking DDL detected:\n$BLOCKING"
+    echo "Abort migration."
+    exit 1
+fi
+
+alembic upgrade head


### PR DESCRIPTION
## Summary
- add `migrate_safe.sh` helper
- document safe migrations in README

## Testing
- `ruff check app/ scripts/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877b8a2d70832aae982ce080999f0e