### PR TITLE
Add SLO monitoring dashboard

### DIFF
--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -34,3 +34,10 @@ receivers:
    amtool alert add test_error rate=3
    ```
 3. Убедитесь, что сообщение появилось в каналах Slack и Telegram.
+
+## 4. SLO thresholds
+
+- **uptime** \u2265 99 %
+- **latency_p95** < 2 s
+
+![SLO dashboard](https://example.com/grafana_slo.png)

--- a/monitoring/grafana/slo_1.0.json
+++ b/monitoring/grafana/slo_1.0.json
@@ -1,0 +1,33 @@
+{
+  "dashboard": {
+    "title": "Service SLO 1.0",
+    "version": 1,
+    "panels": [
+      {
+        "title": "Uptime %",
+        "type": "stat",
+        "targets": [{"expr": "avg_over_time(up[30d])*100"}]
+      },
+      {
+        "title": "Latency p95",
+        "type": "stat",
+        "targets": [{"expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))"}]
+      },
+      {
+        "title": "Error rate",
+        "type": "stat",
+        "targets": [{"expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))"}]
+      },
+      {
+        "title": "Queue depth",
+        "type": "stat",
+        "targets": [{"expr": "queue_size_pending"}]
+      },
+      {
+        "title": "Payment success %",
+        "type": "stat",
+        "targets": [{"expr": "sum(rate(payment_success_total[1h])) / sum(rate(payment_total[1h])) * 100"}]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add Grafana SLO dashboard JSON
- document SLO thresholds in alerting guide

## Testing
- `ruff check app tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877d90aa54832a8b22debac659e6f7