### PR TITLE
refactor: switch storage to aioboto3

### DIFF
--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Request, UploadFile
-from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError, field_validator
 from sqlalchemy import text
@@ -206,7 +205,7 @@ async def diagnose(
             if len(contents) > 2 * 1024 * 1024:
                 err = ErrorResponse(code="BAD_REQUEST", message="image too large")
                 return JSONResponse(status_code=400, content=err.model_dump())
-            key = await run_in_threadpool(upload_photo, user_id, contents)
+            key = await upload_photo(user_id, contents)
             file_id = key
             try:
                 result = call_gpt_vision_stub(key)
@@ -239,7 +238,7 @@ async def diagnose(
             if len(contents) > 2 * 1024 * 1024:
                 err = ErrorResponse(code="BAD_REQUEST", message="image too large")
                 return JSONResponse(status_code=400, content=err.model_dump())
-            key = await run_in_threadpool(upload_photo, user_id, contents)
+            key = await upload_photo(user_id, contents)
             file_id = key
             try:
                 result = call_gpt_vision_stub(key)

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -2,9 +2,9 @@ import os
 from datetime import datetime, timezone
 from uuid import uuid4
 
-import boto3
+import aioboto3
+from aiobotocore.client import AioBaseClient
 from botocore.exceptions import BotoCoreError, ClientError
-from botocore.client import BaseClient
 from fastapi import HTTPException
 
 from app.config import Settings
@@ -13,10 +13,10 @@ from app.config import Settings
 BUCKET = os.getenv("S3_BUCKET", "agronom")
 _settings: Settings | None = None
 
-_client: BaseClient | None = None
+_client: AioBaseClient | None = None
 
 
-def _make_client() -> BaseClient:
+async def _make_client() -> AioBaseClient:
     endpoint = os.getenv(
         "S3_ENDPOINT",
         _settings.s3_endpoint if _settings is not None else None,
@@ -33,22 +33,23 @@ def _make_client() -> BaseClient:
         "S3_SECRET_KEY",
         _settings.s3_secret_key if _settings is not None else None,
     )
-    return boto3.client(
+    client_ctx = aioboto3.Session().client(
         "s3",
         endpoint_url=endpoint,
         region_name=region,
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
     )
+    return await client_ctx.__aenter__()
 
 
 
 
-def get_client() -> BaseClient:
-    """Return a cached boto3 client, creating it if needed."""
+async def get_client() -> AioBaseClient:
+    """Return a cached aioboto3 client, creating it if needed."""
     global _client
     if _client is None:
-        _client = _make_client()
+        _client = await _make_client()
     return _client
 
 
@@ -59,7 +60,7 @@ def init_storage(cfg: Settings) -> None:
     _client = None
 
 
-def upload_photo(user_id: int, data: bytes) -> str:
+async def upload_photo(user_id: int, data: bytes) -> str:
     """Upload bytes to S3 and return the object key."""
     ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
     key = f"{user_id}/{ts}-{uuid4().hex}.jpg"
@@ -68,7 +69,8 @@ def upload_photo(user_id: int, data: bytes) -> str:
         _settings.s3_bucket if _settings is not None else BUCKET,
     )
     try:
-        get_client().put_object(
+        client = await get_client()
+        await client.put_object(
             Bucket=bucket, Key=key, Body=data, ContentType="image/jpeg"
         )
     except (BotoCoreError, ClientError) as exc:
@@ -92,14 +94,14 @@ def get_public_url(key: str) -> str:
     if base:
         return f"{base.rstrip('/')}/{key}"
 
-    endpoint = get_client().meta.endpoint_url or os.getenv(
+    endpoint = os.getenv(
         "S3_ENDPOINT",
         _settings.s3_endpoint if _settings is not None else None,
     )
     if endpoint:
         return f"{endpoint.rstrip('/')}/{bucket}/{key}"
 
-    region = get_client().meta.region_name or os.getenv(
+    region = os.getenv(
         "S3_REGION",
         _settings.s3_region if _settings is not None else "us-east-1",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ zipp==3.20.2
 python-dotenv
 
 httpx==0.27.0
-boto3==1.34.113
+aioboto3==15.0.0
 moto[s3]==5.0.12
 pytest-asyncio==1.1.0
 requests==2.32.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ from app.services.protocols import import_csv_to_db
 @pytest.fixture(autouse=True)
 def stub_upload(monkeypatch):
     """Prevent real S3 calls by stubbing upload_photo."""
-    def _stub(user_id: int, data: bytes) -> str:
+    async def _stub(user_id: int, data: bytes) -> str:
         return "1/stub.jpg"
 
     monkeypatch.setattr("app.services.storage.upload_photo", _stub)


### PR DESCRIPTION
## Summary
- use `aioboto3` async client
- make storage helper methods asynchronous
- call new async helpers from controllers
- update tests for async storage API

## Testing
- `ruff check app/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688798106a34832aa7161aff9e83a002