### PR TITLE
[feature] enhance retry worker reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "dotenv": "^17.2.1",
         "ioredis": "^5.3.2",
         "node-vault": "^0.10.5",
-        "pg": "^8.11.5"
+        "pg": "^8.11.5",
+        "prom-client": "^14.2.0"
       },
       "devDependencies": {
         "@stoplight/spectral-cli": "^6.15.0",
@@ -1217,6 +1218,12 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bluebird": {
       "version": "2.11.0",
@@ -3494,6 +3501,18 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/prom-client": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -4164,6 +4183,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dotenv": "^17.2.1",
     "ioredis": "^5.3.2",
     "pg": "^8.11.5",
-    "node-vault": "^0.10.5"
+    "node-vault": "^0.10.5",
+    "prom-client": "^14.2.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/tests/test_retry_worker.py
+++ b/tests/test_retry_worker.py
@@ -15,3 +15,10 @@ def test_retry_worker_has_retry_limit():
     content = pathlib.Path("worker/retry_diagnosis.js").read_text(encoding="utf-8")
     assert "process.env.RETRY_LIMIT" in content
     assert "retry_attempts=retry_attempts+1" in content
+
+
+def test_retry_worker_exports_metrics():
+    content = pathlib.Path("worker/retry_diagnosis.js").read_text(encoding="utf-8")
+    assert "prom-client" in content
+    assert "METRICS_PORT" in content
+    assert "SLACK_WEBHOOK_URL" in content

--- a/worker/retry_diagnosis.js
+++ b/worker/retry_diagnosis.js
@@ -1,12 +1,60 @@
 require('dotenv').config();
+const http = require('http');
 const { Queue, Worker } = require('bullmq');
 const { Pool } = require('pg');
+const { Counter, Registry, collectDefaultMetrics } = require('prom-client');
 const { callGptVisionStub } = require('./gpt_stub');
 
 const connection = { connectionString: process.env.REDIS_URL || 'redis://localhost:6379' };
 const queueName = 'retry-diagnosis';
 
 const queue = new Queue(queueName, { connection });
+queue.on('error', (err) => {
+  console.error('Redis error', err);
+});
+
+const register = new Registry();
+collectDefaultMetrics({ register });
+const failureCounter = new Counter({
+  name: 'retry_failures_total',
+  help: 'Total failed retry attempts',
+  registers: [register],
+});
+const successCounter = new Counter({
+  name: 'retry_success_total',
+  help: 'Total successful retry attempts',
+  registers: [register],
+});
+const processedCounter = new Counter({
+  name: 'retry_processed_total',
+  help: 'Total processed rows',
+  registers: [register],
+});
+
+const METRICS_PORT = parseInt(process.env.METRICS_PORT || '9102', 10);
+http
+  .createServer(async (_req, res) => {
+    res.setHeader('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  })
+  .listen(METRICS_PORT, () => {
+    console.log(`Metrics server running on ${METRICS_PORT}`);
+  });
+
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+
+async function notifySlack(text) {
+  if (!SLACK_WEBHOOK_URL) return;
+  try {
+    await fetch(SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+  } catch (err) {
+    console.error('Failed to send Slack notification', err);
+  }
+}
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
@@ -17,6 +65,12 @@ const RETRY_LIMIT = parseInt(process.env.RETRY_LIMIT || '3', 10);
 console.log(`Retry diagnosis worker concurrency=${RETRY_CONCURRENCY}`);
 
 async function schedule() {
+  try {
+    await queue.waitUntilReady();
+  } catch (err) {
+    console.error('Redis connection failed', err);
+    process.exit(1);
+  }
   await queue.add(
     'retry',
     {},
@@ -29,15 +83,22 @@ async function schedule() {
 
 schedule();
 
-new Worker(
+const worker = new Worker(
   queueName,
   async () => {
-    const client = await pool.connect();
+    let client;
+    try {
+      client = await pool.connect();
+    } catch (err) {
+      console.error('DB connection failed', err);
+      await notifySlack('Retry worker: unable to connect to DB');
+      throw err;
+    }
     let processed = 0;
     let success = 0;
     let failed = 0;
     try {
-      const { rows } = await client.query("SELECT id, file_id FROM photos WHERE status='pending'");
+      const { rows } = await client.query("SELECT id, file_id, retry_attempts FROM photos WHERE status='pending'");
       processed = rows.length;
       for (const row of rows) {
         try {
@@ -47,6 +108,7 @@ new Worker(
             [resp.crop || null, resp.disease || null, resp.confidence || 0, row.id]
           );
           success += 1;
+          successCounter.inc();
         } catch (err) {
           await client.query(
             "UPDATE photos SET retry_attempts=retry_attempts+1, " +
@@ -55,8 +117,13 @@ new Worker(
             [row.id, RETRY_LIMIT]
           );
           failed += 1;
+          failureCounter.inc();
+          if (row.retry_attempts + 1 >= RETRY_LIMIT) {
+            await notifySlack(`Diagnosis ${row.id} exceeded retry limit`);
+          }
         }
       }
+      processedCounter.inc(processed);
       console.log(
         `Retry diagnosis: processed=${processed} success=${success} failed=${failed}`
       );
@@ -66,3 +133,6 @@ new Worker(
   },
   { connection, concurrency: RETRY_CONCURRENCY }
 );
+worker.on('error', (err) => {
+  console.error('Worker error', err);
+});


### PR DESCRIPTION
## Summary
- handle Redis and DB connection errors
- expose retry metrics via prom-client
- notify Slack when retry limit is exceeded
- update tests for new metrics

## Testing
- `ruff check app tests`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6887a3b451d4832abb688cd534a5a87a