### PR TITLE
[fix] normalize DB URL for migrate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ agronom-bot/
    RETRY_LIMIT=3
    ```
 
+`DATABASE_URL` и `BOT_DATABASE_URL` поддерживают форматы `postgresql://` и
+`postgresql+<driver>://` (например, `postgresql+psycopg://`). Скрипт
+`migrate_safe.sh` автоматически преобразует такие DSN к виду
+`postgresql://` перед передачей в `psql`.
+
 2. Создайте виртуальное окружение под **Python 3.12** (в нём уже есть SQLite 3.35+):
 
    ```bash


### PR DESCRIPTION
## Summary
- handle `postgresql+driver://` DSNs in `migrate_safe.sh`
- document supported URL formats in README

## Testing
- `ruff check app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c06c6cb8832a9bb9c2a01ce473c9