### PR TITLE
Remove unused DATABASE_URL constant

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,13 +1,9 @@
-import os
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 from app.models import Base
 from app.config import Settings
-
-
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
 # Engine and session factory are created lazily via ``init_db``.
 engine: Engine | None = None


### PR DESCRIPTION
## Summary
- clean up `app/db.py`
- drop the hardcoded `DATABASE_URL` constant

## Testing
- `ruff check app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c29a782c832ab4e8f9b1662992d1