### PR TITLE
fix: handle existing columns in payments migration

### DIFF
--- a/migrations/versions/1848f456e8dd_update_payments_table.py
+++ b/migrations/versions/1848f456e8dd_update_payments_table.py
@@ -18,22 +18,42 @@ depends_on = None
 
 def upgrade() -> None:
     """Add new fields to payments table and rename source to provider."""
-    op.add_column("payments", sa.Column("provider", sa.String))
-    op.execute("UPDATE payments SET provider = source")
-    op.drop_column("payments", "source")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    cols = {c["name"] for c in inspector.get_columns("payments")}
 
-    op.add_column("payments", sa.Column("currency", sa.String))
-    op.add_column("payments", sa.Column("updated_at", sa.DateTime))
-    op.add_column("payments", sa.Column("external_id", sa.String))
-    op.add_column("payments", sa.Column("prolong_months", sa.Integer))
+    if "provider" not in cols:
+        op.add_column("payments", sa.Column("provider", sa.String))
+    if "source" in cols:
+        op.execute("UPDATE payments SET provider = source")
+        op.drop_column("payments", "source")
+
+    if "currency" not in cols:
+        op.add_column("payments", sa.Column("currency", sa.String))
+    if "updated_at" not in cols:
+        op.add_column("payments", sa.Column("updated_at", sa.DateTime))
+    if "external_id" not in cols:
+        op.add_column("payments", sa.Column("external_id", sa.String))
+    if "prolong_months" not in cols:
+        op.add_column("payments", sa.Column("prolong_months", sa.Integer))
 
 def downgrade() -> None:
     """Revert payments table changes."""
-    op.drop_column("payments", "prolong_months")
-    op.drop_column("payments", "external_id")
-    op.drop_column("payments", "updated_at")
-    op.drop_column("payments", "currency")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    cols = {c["name"] for c in inspector.get_columns("payments")}
 
-    op.add_column("payments", sa.Column("source", sa.String))
+    if "prolong_months" in cols:
+        op.drop_column("payments", "prolong_months")
+    if "external_id" in cols:
+        op.drop_column("payments", "external_id")
+    if "updated_at" in cols:
+        op.drop_column("payments", "updated_at")
+    if "currency" in cols:
+        op.drop_column("payments", "currency")
+
+    if "source" not in cols:
+        op.add_column("payments", sa.Column("source", sa.String))
     op.execute("UPDATE payments SET source = provider")
-    op.drop_column("payments", "provider")
+    if "provider" in cols:
+        op.drop_column("payments", "provider")


### PR DESCRIPTION
## Summary
- update payments migration to avoid adding columns that already exist

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688986fd8784832aa6fe1fbf7d2e35d1