### PR TITLE
Expand docker compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,81 @@ version: '3.9'
 services:
   api:
     build: .
+    env_file: .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      S3_ENDPOINT: ${S3_ENDPOINT}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+      S3_SECRET_KEY: ${S3_SECRET_KEY}
+    volumes:
+      - ./openapi/openapi.yaml:/app/openapi/openapi.yaml
+    depends_on:
+      - postgres
+      - redis
+      - minio
     ports:
       - "8000:8000"
+  bot:
+    image: node:18
+    working_dir: /usr/src/app
+    command: node bot/index.js
+    volumes:
+      - .:/usr/src/app
+    env_file: .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      BOT_DATABASE_URL: ${BOT_DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      S3_ENDPOINT: ${S3_ENDPOINT}
+    depends_on:
+      - api
+      - postgres
+      - redis
+      - minio
+  postgres:
+    image: postgres:14
+    restart: unless-stopped
+    env_file: .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    restart: unless-stopped
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    env_file: .env
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - prometheus_data:/prometheus
+  loki:
+    image: grafana/loki:2.9.7
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki_data:/loki
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+
+volumes:
+  postgres_data:
+  minio_data:
+  prometheus_data:
+  loki_data:
+  grafana_data:


### PR DESCRIPTION
## Summary
- define services for API, bot, Postgres, Redis, MinIO, Prometheus, Loki and Grafana
- mount OpenAPI spec and share env vars via `.env`
- create named volumes for persistent data

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: CalledProcessError: alembic upgrade head)*
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_688b2f9bb874832ab057ad574e8c0685