### PR TITLE
Update compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,94 @@ version: '3.9'
 services:
   api:
     build: .
+    env_file: .env
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - S3_ENDPOINT=${S3_ENDPOINT}
     ports:
       - "8000:8000"
+    volumes:
+      - ./openapi/openapi.yaml:/app/openapi/openapi.yaml:ro
+    depends_on:
+      - postgres
+      - redis
+      - minio
+
+  bot:
+    image: node:18
+    working_dir: /app
+    command: sh -c "npm ci --prefix bot && node bot/index.js"
+    env_file: .env
+    environment:
+      - DATABASE_URL=${BOT_DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - API_BASE_URL=http://api:8000
+    volumes:
+      - .:/app
+    depends_on:
+      - api
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:14
+    env_file: .env
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    env_file: .env
+    environment:
+      - MINIO_ROOT_USER=${S3_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${S3_SECRET_KEY}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+
+  loki:
+    image: grafana/loki:latest
+    volumes:
+      - loki-data:/loki
+    ports:
+      - "3100:3100"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana:/etc/grafana/provisioning/dashboards:ro
+    depends_on:
+      - prometheus
+      - loki
+
+volumes:
+  postgres-data:
+  minio-data:
+  prometheus-data:
+  grafana-data:
+  loki-data:


### PR DESCRIPTION
## Summary
- compose API build from Dockerfile and mount openapi spec
- add bot service on Node 18
- add postgres, redis, minio, prometheus, loki and grafana
- configure env vars from `.env` and set inter-service dependencies
- create named volumes for data storage

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: OperationalError when running Alembic migrations)*
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688b05343a28832ab7b8c76630174f91