### PR TITLE
Add Prometheus and Grafana configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     image: prom/prometheus
     volumes:
       - prometheus_data:/prometheus
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
   loki:
     image: grafana/loki:2.9.7
     command: -config.file=/etc/loki/local-config.yaml
@@ -70,6 +71,7 @@ services:
       - "3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - prometheus
       - loki

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: api
+    static_configs:
+      - targets: ['api:8000']
+  - job_name: bot
+    static_configs:
+      - targets: ['bot:3000']


### PR DESCRIPTION
## Summary
- provide Prometheus scrape configuration for the API and bot
- configure Grafana datasources for Prometheus and Loki
- mount monitoring configs in docker-compose

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: Command '['alembic', 'upgrade', 'head']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688b3c76a580832aa42e4b4383974d25