### PR TITLE
Add Node 18 Dockerfile for bot

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY bot/package*.json ./bot/
+RUN npm ci --prefix bot
+COPY . .
+ENTRYPOINT ["node", "bot/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
     ports:
       - "8000:8000"
   bot:
-    image: node:18
-    working_dir: /usr/src/app
-    command: node bot/index.js
+    build:
+      context: .
+      dockerfile: bot/Dockerfile
     volumes:
       - .:/usr/src/app
     env_file: .env


### PR DESCRIPTION
## Summary
- add Dockerfile for the Telegram bot
- build bot service using the Dockerfile

## Testing
- `ruff check app tests`
- `pytest -q` *(fails: alembic upgrade head exited with status 1)*
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_688b42e531ec832a9c7c2d18bd194055