### PR TITLE
refactor(storage): properly close aioboto3 client

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from app.config import Settings
 from app.db import init_db
 from app.services.protocols import import_csv_to_db
-from app.services.storage import init_storage
+from app.services.storage import init_storage, close_client
 from app.logger import setup_logging
 from app.controllers import v1
 
@@ -16,16 +16,17 @@ from app.controllers import v1
 from prometheus_fastapi_instrumentator import Instrumentator
 
 settings = Settings()
-init_storage(settings)
 setup_logging()
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    await init_storage(settings)
     init_db(settings)
     import_csv_to_db()
     yield
+    await close_client()
 
 
 app = FastAPI(


### PR DESCRIPTION
## Summary
- ensure storage S3 client is created with a reusable context and closed on shutdown
- wire close_client into FastAPI lifespan so resources are freed
- test storage client lifecycle to avoid unclosed resources

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dfdca1138832aa4b053e3629fb4da