### PR TITLE
refactor: offload blocking db work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ and **Node.js 18+** for the bot.
 - Install bot deps with `npm ci --prefix bot` and run tests via
   `npm test --prefix bot`.
 - Run linting with `ruff check app tests` and Python tests via `pytest`.
+- In async FastAPI handlers, avoid blocking DB calls: wrap `SessionLocal`
+  work in `asyncio.to_thread` or use SQLAlchemy async sessions.
 
 Pull requests must target **develop** and pass all tests and linters. Update the
 documentation whenever behaviour or APIs change. See the detailed Russian guide

--- a/README.md
+++ b/README.md
@@ -235,6 +235,21 @@ agronom-bot/
     Тесты игнорируют файл `.env`, так как `Settings(_env_file=None)` передаётся в
     хранилище. Локальные переменные вроде `S3_ENDPOINT` не повлияют на результат.
 
+### Асинхронный доступ к БД
+
+Эндпоинты FastAPI работают в асинхронном режиме. Чтобы не блокировать
+event loop, оборачивайте синхронный `SessionLocal` в `asyncio.to_thread` или
+используйте асинхронный движок SQLAlchemy.
+
+```python
+def _db_task():
+    with db.SessionLocal() as session:
+        session.add(obj)
+        session.commit()
+
+await asyncio.to_thread(_db_task)
+```
+
 7. Проверьте спецификацию OpenAPI линтером Spectral:
 
    ```bash

--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sqlite3
+import asyncio
 from datetime import datetime, timezone, timedelta
 from uuid import uuid4
 from zoneinfo import ZoneInfo
@@ -154,119 +155,145 @@ async def diagnose(
     image: UploadFile | None = OPTIONAL_FILE,
     prompt_id: str | None = Form(None),
 ):
-    with db_module.SessionLocal() as db:
-        status = "ok"
-        moscow_tz = ZoneInfo("Europe/Moscow")
-        month_key = datetime.now(moscow_tz).strftime("%Y-%m")
-        params = {"uid": user_id, "month": month_key}
-        if sqlite3.sqlite_version_info >= (3, 35):
-            stmt = text(
-                "INSERT INTO photo_usage (user_id, month, used, updated_at) "
-                "VALUES (:uid, :month, 1, CURRENT_TIMESTAMP) "
-                "ON CONFLICT(user_id, month) DO UPDATE "
-                "SET used = photo_usage.used + 1, "
-                "updated_at = CURRENT_TIMESTAMP RETURNING used"
-            )
-            used = db.execute(stmt, params).scalar_one()
-        else:
-            stmt = text(
-                "INSERT INTO photo_usage (user_id, month, used, updated_at) "
-                "VALUES (:uid, :month, 1, CURRENT_TIMESTAMP) "
-                "ON CONFLICT(user_id, month) DO UPDATE "
-                "SET used = photo_usage.used + 1, "
-                "updated_at = CURRENT_TIMESTAMP"
-            )
-            db.execute(stmt, params)
-            used = db.execute(
-                text(
-                    "SELECT used FROM photo_usage WHERE user_id=:uid AND month=:month"
-                ),
-                params,
-            ).scalar_one()
+    async def _increment_usage() -> tuple[int, datetime | None]:
+        def _db() -> tuple[int, datetime | None]:
+            with db_module.SessionLocal() as db:
+                moscow_tz = ZoneInfo("Europe/Moscow")
+                month_key = datetime.now(moscow_tz).strftime("%Y-%m")
+                params = {"uid": user_id, "month": month_key}
+                if sqlite3.sqlite_version_info >= (3, 35):
+                    stmt = text(
+                        "INSERT INTO photo_usage (user_id, month, used, updated_at) "
+                        "VALUES (:uid, :month, 1, CURRENT_TIMESTAMP) "
+                        "ON CONFLICT(user_id, month) DO UPDATE "
+                        "SET used = photo_usage.used + 1, "
+                        "updated_at = CURRENT_TIMESTAMP RETURNING used"
+                    )
+                    used = db.execute(stmt, params).scalar_one()
+                else:
+                    stmt = text(
+                        "INSERT INTO photo_usage (user_id, month, used, updated_at) "
+                        "VALUES (:uid, :month, 1, CURRENT_TIMESTAMP) "
+                        "ON CONFLICT(user_id, month) DO UPDATE "
+                        "SET used = photo_usage.used + 1, "
+                        "updated_at = CURRENT_TIMESTAMP"
+                    )
+                    db.execute(stmt, params)
+                    used = db.execute(
+                        text(
+                            "SELECT used FROM photo_usage WHERE user_id=:uid AND month=:month"
+                        ),
+                        params,
+                    ).scalar_one()
 
-        db.commit()
-
-        pro = db.execute(
-            text("SELECT pro_expires_at FROM users WHERE id=:uid"),
-            {"uid": user_id},
-        ).scalar()
-        if isinstance(pro, str):
-            pro = datetime.fromisoformat(pro)
-        now_utc = datetime.now(timezone.utc)
-        if PAYWALL_ENABLED and used > FREE_MONTHLY_LIMIT and (not pro or pro < now_utc):
-            if pro and pro < now_utc:
-                db.add(Event(user_id=user_id, event="pro_expired"))
                 db.commit()
-            return JSONResponse(status_code=402, content={"error": "limit_reached", "limit": FREE_MONTHLY_LIMIT})
 
-        if image:
-            if prompt_id not in (None, "v1"):
-                err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
-                return JSONResponse(status_code=400, content=err.model_dump())
-            contents = await image.read()
-            if len(contents) > 2 * 1024 * 1024:
-                err = ErrorResponse(code="BAD_REQUEST", message="image too large")
-                return JSONResponse(status_code=400, content=err.model_dump())
-            key = await upload_photo(user_id, contents)
-            file_id = key
-            try:
-                result = call_gpt_vision_stub(key)
-                crop = result.get("crop", "")
-                disease = result.get("disease", "")
-                conf = result.get("confidence", 0.0)
-                status = "ok"
-            except Exception as exc:
-                logger.exception("GPT error", exc_info=exc)
-                crop = ""
-                disease = ""
-                conf = 0.0
-                status = "pending"
-        else:
-            try:
-                json_data = await request.json()
-            except Exception:
-                err = ErrorResponse(code="BAD_REQUEST", message="invalid JSON")
-                return JSONResponse(status_code=400, content=err.model_dump())
-            try:
-                body = DiagnoseRequestBase64(**json_data)
-            except ValidationError:
-                err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
-                return JSONResponse(status_code=400, content=err.model_dump())
-            try:
-                contents = base64.b64decode(body.image_base64, validate=True)
-            except binascii.Error:
-                err = ErrorResponse(code="BAD_REQUEST", message="invalid base64")
-                return JSONResponse(status_code=400, content=err.model_dump())
-            if len(contents) > 2 * 1024 * 1024:
-                err = ErrorResponse(code="BAD_REQUEST", message="image too large")
-                return JSONResponse(status_code=400, content=err.model_dump())
-            key = await upload_photo(user_id, contents)
-            file_id = key
-            try:
-                result = call_gpt_vision_stub(key)
-                crop = result.get("crop", "")
-                disease = result.get("disease", "")
-                conf = result.get("confidence", 0.0)
-                status = "ok"
-            except Exception as exc:
-                logger.exception("GPT error", exc_info=exc)
-                crop = ""
-                disease = ""
-                conf = 0.0
-                status = "pending"
+                pro = db.execute(
+                    text("SELECT pro_expires_at FROM users WHERE id=:uid"),
+                    {"uid": user_id},
+                ).scalar()
+                if isinstance(pro, str):
+                    pro = datetime.fromisoformat(pro)
+                return used, pro
 
-        photo = Photo(
-            user_id=user_id,
-            file_id=file_id,
-            crop=crop,
-            disease=disease,
-            confidence=conf,
-            status=status,
+        return await asyncio.to_thread(_db)
+
+    used, pro = await _increment_usage()
+    now_utc = datetime.now(timezone.utc)
+    if PAYWALL_ENABLED and used > FREE_MONTHLY_LIMIT and (not pro or pro < now_utc):
+        if pro and pro < now_utc:
+            def _log() -> None:
+                with db_module.SessionLocal() as db:
+                    db.add(Event(user_id=user_id, event="pro_expired"))
+                    db.commit()
+
+            await asyncio.to_thread(_log)
+        return JSONResponse(
+            status_code=402,
+            content={"error": "limit_reached", "limit": FREE_MONTHLY_LIMIT},
         )
-        db.add(photo)
-        db.commit()
-        if status != "ok":
-            return JSONResponse(status_code=202, content={"id": photo.id, "status": "pending"})
+
+    status = "ok"
+    file_id = ""
+    crop = ""
+    disease = ""
+    conf = 0.0
+
+    if image:
+        if prompt_id not in (None, "v1"):
+            err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        contents = await image.read()
+        if len(contents) > 2 * 1024 * 1024:
+            err = ErrorResponse(code="BAD_REQUEST", message="image too large")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        key = await upload_photo(user_id, contents)
+        file_id = key
+        try:
+            result = call_gpt_vision_stub(key)
+            crop = result.get("crop", "")
+            disease = result.get("disease", "")
+            conf = result.get("confidence", 0.0)
+            status = "ok"
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("GPT error", exc_info=exc)
+            crop = ""
+            disease = ""
+            conf = 0.0
+            status = "pending"
+    else:
+        try:
+            json_data = await request.json()
+        except Exception:  # noqa: BLE001
+            err = ErrorResponse(code="BAD_REQUEST", message="invalid JSON")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        try:
+            body = DiagnoseRequestBase64(**json_data)
+        except ValidationError:
+            err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        try:
+            contents = base64.b64decode(body.image_base64, validate=True)
+        except binascii.Error:
+            err = ErrorResponse(code="BAD_REQUEST", message="invalid base64")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        if len(contents) > 2 * 1024 * 1024:
+            err = ErrorResponse(code="BAD_REQUEST", message="image too large")
+            return JSONResponse(status_code=400, content=err.model_dump())
+        key = await upload_photo(user_id, contents)
+        file_id = key
+        try:
+            result = call_gpt_vision_stub(key)
+            crop = result.get("crop", "")
+            disease = result.get("disease", "")
+            conf = result.get("confidence", 0.0)
+            status = "ok"
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("GPT error", exc_info=exc)
+            crop = ""
+            disease = ""
+            conf = 0.0
+            status = "pending"
+
+    def _save() -> int:
+        with db_module.SessionLocal() as db:
+            photo = Photo(
+                user_id=user_id,
+                file_id=file_id,
+                crop=crop,
+                disease=disease,
+                confidence=conf,
+                status=status,
+            )
+            db.add(photo)
+            db.commit()
+            return photo.id
+
+    photo_id = await asyncio.to_thread(_save)
+    if status != "ok":
+        return JSONResponse(
+            status_code=202, content={"id": photo_id, "status": "pending"}
+        )
 
     proto = find_protocol(crop, disease)
     if proto:
@@ -304,33 +331,36 @@ async def list_photos(
     if limit <= 0:
         return ListPhotosResponse(items=[], next_cursor=None)
 
-    with db_module.SessionLocal() as db:
-        q = (
-            db.query(Photo)
-            .filter(Photo.user_id == user_id, Photo.deleted.is_(False))
-            .order_by(Photo.id.desc())
-        )
-        if cursor:
-            try:
-                last_id = int(cursor)
-                q = q.filter(Photo.id < last_id)
-            except ValueError as err:
-                raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
-
-        limit = min(limit, 50)
-        rows = q.limit(limit).all()
-        items = [
-            PhotoItem(
-                id=r.id,
-                ts=r.ts,
-                crop=r.crop or "",
-                disease=r.disease or "",
-                confidence=float(r.confidence or 0),
+    def _db_call() -> tuple[list[PhotoItem], str | None]:
+        with db_module.SessionLocal() as db:
+            q = (
+                db.query(Photo)
+                .filter(Photo.user_id == user_id, Photo.deleted.is_(False))
+                .order_by(Photo.id.desc())
             )
-            for r in rows
-        ]
-        next_cursor = str(rows[-1].id) if len(rows) == limit else None
+            if cursor:
+                try:
+                    last_id = int(cursor)
+                    q = q.filter(Photo.id < last_id)
+                except ValueError as err:
+                    raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
 
+            limit_local = min(limit, 50)
+            rows = q.limit(limit_local).all()
+            items_local = [
+                PhotoItem(
+                    id=r.id,
+                    ts=r.ts,
+                    crop=r.crop or "",
+                    disease=r.disease or "",
+                    confidence=float(r.confidence or 0),
+                )
+                for r in rows
+            ]
+            next_cur = str(rows[-1].id) if len(rows) == limit_local else None
+            return items_local, next_cur
+
+    items, next_cursor = await asyncio.to_thread(_db_call)
     return ListPhotosResponse(items=items, next_cursor=next_cursor)
 
 
@@ -347,28 +377,30 @@ async def list_photos_history(
     limit = max(0, min(limit, 50))
     offset = max(0, offset)
 
-    with db_module.SessionLocal() as db:
-        rows = (
-            db.query(Photo)
-            .filter(Photo.user_id == user_id, Photo.deleted.is_(False))
-            .order_by(Photo.ts.desc())
-            .limit(limit)
-            .offset(offset)
-            .all()
-        )
+    def _db_call() -> list[PhotoHistoryItem]:
+        with db_module.SessionLocal() as db:
+            rows = (
+                db.query(Photo)
+                .filter(Photo.user_id == user_id, Photo.deleted.is_(False))
+                .order_by(Photo.ts.desc())
+                .limit(limit)
+                .offset(offset)
+                .all()
+            )
+            return [
+                PhotoHistoryItem(
+                    photo_id=r.id,
+                    ts=r.ts,
+                    crop=r.crop or "",
+                    disease=r.disease or "",
+                    status=r.status,
+                    confidence=float(r.confidence or 0),
+                    thumb_url=get_public_url(r.file_id),
+                )
+                for r in rows
+            ]
 
-    return [
-        PhotoHistoryItem(
-            photo_id=r.id,
-            ts=r.ts,
-            crop=r.crop or "",
-            disease=r.disease or "",
-            status=r.status,
-            confidence=float(r.confidence or 0),
-            thumb_url=get_public_url(r.file_id),
-        )
-        for r in rows
-    ]
+    return await asyncio.to_thread(_db_call)
 
 
 @router.get(
@@ -377,13 +409,21 @@ async def list_photos_history(
     responses={401: {"model": ErrorResponse}},
 )
 async def get_limits(user_id: int = Depends(require_api_headers)):
-    with db_module.SessionLocal() as db:
-        moscow_tz = ZoneInfo("Europe/Moscow")
-        month_key = datetime.now(moscow_tz).strftime("%Y-%m")
-        used = db.execute(
-            text("SELECT used FROM photo_usage WHERE user_id=:uid AND month=:month"),
-            {"uid": user_id, "month": month_key},
-        ).scalar() or 0
+    def _db_call() -> int:
+        with db_module.SessionLocal() as db:
+            moscow_tz = ZoneInfo("Europe/Moscow")
+            month_key = datetime.now(moscow_tz).strftime("%Y-%m")
+            return (
+                db.execute(
+                    text(
+                        "SELECT used FROM photo_usage WHERE user_id=:uid AND month=:month"
+                    ),
+                    {"uid": user_id, "month": month_key},
+                ).scalar()
+                or 0
+            )
+
+    used = await asyncio.to_thread(_db_call)
     return LimitsResponse(limit_monthly_free=FREE_MONTHLY_LIMIT, used_this_month=used)
 
 
@@ -401,20 +441,22 @@ async def create_payment(body: PaymentCreateRequest, _: None = Depends(require_a
     external_id = uuid4().hex
     url = create_sbp_link(external_id, amount, currency)
 
-    with db_module.SessionLocal() as db:
-        payment = Payment(
-            user_id=body.user_id,
-            amount=amount,
-            currency=currency,
-            provider="sbp",
-            external_id=external_id,
-            prolong_months=body.months,
-            status="pending",
-        )
-        db.add(payment)
-        db.add(Event(user_id=body.user_id, event="payment_created"))
-        db.commit()
+    def _db_call() -> None:
+        with db_module.SessionLocal() as db:
+            payment = Payment(
+                user_id=body.user_id,
+                amount=amount,
+                currency=currency,
+                provider="sbp",
+                external_id=external_id,
+                prolong_months=body.months,
+                status="pending",
+            )
+            db.add(payment)
+            db.add(Event(user_id=body.user_id, event="payment_created"))
+            db.commit()
 
+    await asyncio.to_thread(_db_call)
     return PaymentCreateResponse(payment_id=external_id, url=url)
 
 
@@ -424,15 +466,19 @@ async def create_payment(body: PaymentCreateRequest, _: None = Depends(require_a
     responses={401: {"model": ErrorResponse}},
 )
 async def payment_status(payment_id: str, _: None = Depends(require_api_headers)):
-    with db_module.SessionLocal() as db:
-        payment = db.query(Payment).filter_by(external_id=payment_id).first()
-        if not payment:
-            raise HTTPException(status_code=404, detail="NOT_FOUND")
-        exp = db.execute(
-            text("SELECT pro_expires_at FROM users WHERE id=:uid"),
-            {"uid": payment.user_id},
-        ).scalar()
-    return PaymentStatusResponse(status=payment.status, pro_expires_at=exp)
+    def _db_call() -> tuple[str, datetime | None]:
+        with db_module.SessionLocal() as db:
+            payment = db.query(Payment).filter_by(external_id=payment_id).first()
+            if not payment:
+                raise HTTPException(status_code=404, detail="NOT_FOUND")
+            exp = db.execute(
+                text("SELECT pro_expires_at FROM users WHERE id=:uid"),
+                {"uid": payment.user_id},
+            ).scalar()
+            return payment.status, exp
+
+    status, exp = await asyncio.to_thread(_db_call)
+    return PaymentStatusResponse(status=status, pro_expires_at=exp)
 
 
 @router.post(
@@ -462,37 +508,39 @@ async def payments_webhook(
     except ValidationError as err:
         raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
 
-    with db_module.SessionLocal() as db:
-        payment = db.query(Payment).filter_by(external_id=body.external_id).first()
-        if not payment:
-            raise HTTPException(status_code=404, detail="NOT_FOUND")
-        payment.status = body.status
-        payment.updated_at = datetime.now(timezone.utc)
-        db.add(payment)
+    def _db_call() -> None:
+        with db_module.SessionLocal() as db:
+            payment = db.query(Payment).filter_by(external_id=body.external_id).first()
+            if not payment:
+                raise HTTPException(status_code=404, detail="NOT_FOUND")
+            payment.status = body.status
+            payment.updated_at = datetime.now(timezone.utc)
+            db.add(payment)
 
-        if body.status == "success":
-            months = payment.prolong_months or 0
-            res = db.execute(
-                text("SELECT pro_expires_at FROM users WHERE id=:uid"),
-                {"uid": payment.user_id},
-            ).scalar()
-            current_exp = res or body.paid_at
-            if isinstance(current_exp, str):
-                current_exp = datetime.fromisoformat(current_exp)
-            if current_exp < body.paid_at:
-                current_exp = body.paid_at
-            new_exp = current_exp + timedelta(days=30 * months)
-            db.execute(
-                text("UPDATE users SET pro_expires_at=:exp WHERE id=:uid"),
-                {"uid": payment.user_id, "exp": new_exp},
-            )
-            db.add(Event(user_id=payment.user_id, event="payment_success"))
-            db.add(Event(user_id=payment.user_id, event="pro_activated"))
-        else:
-            db.add(Event(user_id=payment.user_id, event="payment_fail"))
+            if body.status == "success":
+                months = payment.prolong_months or 0
+                res = db.execute(
+                    text("SELECT pro_expires_at FROM users WHERE id=:uid"),
+                    {"uid": payment.user_id},
+                ).scalar()
+                current_exp = res or body.paid_at
+                if isinstance(current_exp, str):
+                    current_exp = datetime.fromisoformat(current_exp)
+                if current_exp < body.paid_at:
+                    current_exp = body.paid_at
+                new_exp = current_exp + timedelta(days=30 * months)
+                db.execute(
+                    text("UPDATE users SET pro_expires_at=:exp WHERE id=:uid"),
+                    {"uid": payment.user_id, "exp": new_exp},
+                )
+                db.add(Event(user_id=payment.user_id, event="payment_success"))
+                db.add(Event(user_id=payment.user_id, event="pro_activated"))
+            else:
+                db.add(Event(user_id=payment.user_id, event="payment_fail"))
 
-        db.commit()
+            db.commit()
 
+    await asyncio.to_thread(_db_call)
     return {}
 
 
@@ -512,17 +560,20 @@ async def partner_orders(
     except ValidationError as err:
         raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
 
-    with db_module.SessionLocal() as db:
-        order = PartnerOrder(
-            user_id=body.user_tg_id,
-            order_id=body.order_id,
-            protocol_id=body.protocol_id,
-            price_kopeks=body.price_kopeks,
-            signature=sign,
-            status="new",
-        )
-        db.add(order)
-        db.commit()
+    def _db_call() -> None:
+        with db_module.SessionLocal() as db:
+            order = PartnerOrder(
+                user_id=body.user_tg_id,
+                order_id=body.order_id,
+                protocol_id=body.protocol_id,
+                price_kopeks=body.price_kopeks,
+                signature=sign,
+                status="new",
+            )
+            db.add(order)
+            db.commit()
+
+    await asyncio.to_thread(_db_call)
     return JSONResponse(status_code=202, content={"status": "queued"})
 
 
@@ -532,14 +583,29 @@ async def partner_orders(
     responses={401: {"model": ErrorResponse}, 404: {"description": "Not found"}},
 )
 async def photo_status(photo_id: int, user_id: int = Depends(require_api_headers)):
-    with db_module.SessionLocal() as db:
-        photo = db.query(Photo).filter_by(id=photo_id, user_id=user_id, deleted=False).first()
-        if not photo:
-            raise HTTPException(status_code=404, detail="NOT_FOUND")
+    def _db_call() -> dict:
+        with db_module.SessionLocal() as db:
+            photo = db.query(Photo).filter_by(
+                id=photo_id, user_id=user_id, deleted=False
+            ).first()
+            if not photo:
+                raise HTTPException(status_code=404, detail="NOT_FOUND")
+            return {
+                "status": photo.status,
+                "updated_at": photo.ts,
+                "crop": photo.crop,
+                "disease": photo.disease,
+            }
+
+    photo_data = await asyncio.to_thread(_db_call)
 
     proto = None
-    if photo.status == "ok" and photo.crop and photo.disease:
-        p = find_protocol(photo.crop, photo.disease)
+    if (
+        photo_data["status"] == "ok"
+        and photo_data["crop"]
+        and photo_data["disease"]
+    ):
+        p = find_protocol(photo_data["crop"], photo_data["disease"])
         if p:
             proto = ProtocolResponse(
                 id=p.id,
@@ -550,9 +616,9 @@ async def photo_status(photo_id: int, user_id: int = Depends(require_api_headers
             )
 
     return PhotoStatusResponse(
-        status=photo.status,
-        updated_at=photo.ts,
-        crop=photo.crop,
-        disease=photo.disease,
+        status=photo_data["status"],
+        updated_at=photo_data["updated_at"],
+        crop=photo_data["crop"],
+        disease=photo_data["disease"],
         protocol=proto,
     )


### PR DESCRIPTION
## Summary
- use `asyncio.to_thread` to run database work in v1 controller
- document async DB usage in developer guide

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e0311e00c832aa60c62d110c559a6