### PR TITLE
[fix] Handle missing protocols table gracefully

### DIFF
--- a/app/services/protocols.py
+++ b/app/services/protocols.py
@@ -106,12 +106,17 @@ def _cache_protocol(crop: str, disease: str) -> Protocol | None:
     if key in _cache:
         return _cache[key]
     session = db.SessionLocal()
-    proto = (
-        session.query(Protocol)
-        .filter(Protocol.crop == crop, Protocol.disease == disease)
-        .first()
-    )
-    session.close()
+    try:
+        proto = (
+            session.query(Protocol)
+            .filter(Protocol.crop == crop, Protocol.disease == disease)
+            .first()
+        )
+    except OperationalError as exc:
+        logger.warning("Protocols table query failed: %s", exc)
+        return None
+    finally:
+        session.close()
     _cache[key] = proto
     return proto
 


### PR DESCRIPTION
## Summary
- guard protocol lookup against missing `protocols` table and return beta fallback
- test diagnose endpoint when `protocols` table is absent

## Testing
- `ruff check app tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e057f67f4832a838cb11b6bc9fa35