### PR TITLE
feat(monitoring): add payments and infra dashboards

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -5,6 +5,8 @@ providers:
     folder: 'Agronom'
     type: file
     disableDeletion: false
+    allowUiUpdates: true
     updateIntervalSeconds: 10
     options:
       path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/monitoring/grafana/provisioning/dashboards/infra.json
+++ b/monitoring/grafana/provisioning/dashboards/infra.json
@@ -1,0 +1,52 @@
+{
+  "title": "Infrastructure",
+  "panels": [
+    {
+      "title": "CPU usage",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"api|bot\"}[5m])) by (container)" }
+      ]
+    },
+    {
+      "title": "Memory usage",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "container_memory_usage_bytes{container=~\"api|bot\"}" }
+      ]
+    },
+    {
+      "title": "Disk free %",
+      "type": "stat",
+      "targets": [
+        { "expr": "node_filesystem_avail_bytes / node_filesystem_size_bytes * 100" }
+      ]
+    },
+    {
+      "title": "Network receive",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(container_network_receive_bytes_total{container=~\"api|bot\"}[5m])) by (container)" }
+      ]
+    },
+    {
+      "title": "Network transmit",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(container_network_transmit_bytes_total{container=~\"api|bot\"}[5m])) by (container)" }
+      ]
+    },
+    {
+      "title": "Event loop lag",
+      "type": "stat",
+      "targets": [
+        { "expr": "event_loop_lag_seconds" }
+      ]
+    }
+  ],
+  "timezone": "browser",
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "version": 1,
+  "editable": true
+}

--- a/monitoring/grafana/provisioning/dashboards/payments.json
+++ b/monitoring/grafana/provisioning/dashboards/payments.json
@@ -1,0 +1,45 @@
+{
+  "title": "Payments",
+  "panels": [
+    {
+      "title": "Total payments",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(payment_total[5m]))" }
+      ]
+    },
+    {
+      "title": "Successful payments",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(payment_success_total[5m]))" }
+      ]
+    },
+    {
+      "title": "Failed payments",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(payment_fail_total[5m]))" }
+      ]
+    },
+    {
+      "title": "Success %",
+      "type": "stat",
+      "targets": [
+        { "expr": "sum(rate(payment_success_total[5m])) / sum(rate(payment_total[5m])) * 100" }
+      ]
+    },
+    {
+      "title": "Payment latency p95",
+      "type": "stat",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, rate(payment_latency_seconds_bucket[5m]))" }
+      ]
+    }
+  ],
+  "timezone": "browser",
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "version": 1,
+  "editable": true
+}


### PR DESCRIPTION
## Summary
- add Grafana dashboard for payment metrics
- add infrastructure dashboard for api and bot containers
- allow Grafana to load dashboard files recursively

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e0c674a40832a91c20dbb77714272