### PR TITLE
fix: sort protocols service imports

### DIFF
--- a/app/services/protocols.py
+++ b/app/services/protocols.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import csv
 import logging
-from cachetools import TTLCache
 from pathlib import Path
 
+from cachetools import TTLCache
 from sqlalchemy import inspect
 from sqlalchemy.exc import OperationalError
 


### PR DESCRIPTION
## Summary
- ensure `csv` is imported and group protocol service imports consistently

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e13d5d3a0832aa3c9ec89284678fa