### PR TITLE
chore: reorder imports in update_protocols script

### DIFF
--- a/scripts/update_protocols.py
+++ b/scripts/update_protocols.py
@@ -1,6 +1,6 @@
-import argparse
-import csv
 from pathlib import Path
+import csv
+import argparse
 
 import requests
 


### PR DESCRIPTION
## Summary
- reorder update_protocols imports to start with pathlib, csv, argparse

## Testing
- `ruff check scripts/update_protocols.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e203fd740832a81f785a1d90856e0