### PR TITLE
refactor: remove duplicate SBP link helper

### DIFF
--- a/app/services/payments.py
+++ b/app/services/payments.py
@@ -2,6 +2,5 @@
 from __future__ import annotations
 
 
-def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
-    """Return mocked SBP payment URL."""
-    return f"https://sbp.example/pay/{external_id}"
+# The `create_sbp_link` helper moved to :mod:`app.services.sbp`.
+# This module remains for potential future payment utilities.


### PR DESCRIPTION
## Summary
- remove old `create_sbp_link` stub from payments service
- keep single `create_sbp_link` implementation in `app/services/sbp.py`

## Testing
- `ruff check app/services`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e21b070e8832abf3dd8fc5249c461