### PR TITLE
[fix] unify diagnose JSON validation error

### DIFF
--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -249,8 +249,9 @@ async def diagnose(
             return JSONResponse(status_code=400, content=err.model_dump())
         try:
             body = DiagnoseRequestBase64(**json_data)
-        except ValidationError:
-            err = ErrorResponse(code="BAD_REQUEST", message="prompt_id must be 'v1'")
+        except ValidationError as err:
+            message = "; ".join(e.get("msg", "") for e in err.errors())
+            err = ErrorResponse(code="BAD_REQUEST", message=message)
             return JSONResponse(status_code=400, content=err.model_dump())
         try:
             contents = base64.b64decode(body.image_base64, validate=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -167,6 +167,9 @@ def test_diagnose_json_bad_prompt(client):
         json={"image_base64": "dGVzdA==", "prompt_id": "v2"},
     )
     assert resp.status_code == 400
+    data = resp.json()
+    assert data["code"] == "BAD_REQUEST"
+    assert "prompt_id" in data["message"]
 
 
 def test_diagnose_json_missing_prompt(client):
@@ -176,6 +179,9 @@ def test_diagnose_json_missing_prompt(client):
         json={"image_base64": "dGVzdA=="},
     )
     assert resp.status_code == 400
+    data = resp.json()
+    assert data["code"] == "BAD_REQUEST"
+    assert "Field required" in data["message"]
 
 
 def test_diagnose_invalid_base64(client):


### PR DESCRIPTION
## Summary
- return BAD_REQUEST with validation details instead of hardcoded prompt message
- cover bad and missing JSON parameters with stricter tests

## Testing
- `ruff check app/controllers/v1.py`
- `ruff check tests/test_api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e23265818832a907889d4d8b43a35