### PR TITLE
fix: execute search path query via session

### DIFF
--- a/app/services/protocols.py
+++ b/app/services/protocols.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 
 from cachetools import TTLCache
-from sqlalchemy import inspect
+from sqlalchemy import inspect, text
 from sqlalchemy.exc import OperationalError
 
 from app import db
@@ -57,7 +57,7 @@ def import_csv_to_db(path: Path = CSV_PATH, update: bool = False) -> None:
     if logger.isEnabledFor(logging.DEBUG):
         insp = inspect(engine)
         try:
-            search_path = engine.execute("SHOW search_path").scalar()
+            search_path = session.execute(text("SHOW search_path")).scalar()
         except Exception:  # noqa: BLE001
             search_path = "n/a"
         logger.debug("DB url       → %s", engine.url)


### PR DESCRIPTION
## Summary
- use Session.execute + text() for search_path debug query

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2724c690832a938504ff2f6d6a24