### PR TITLE
refactor: rename verify_hmac

### DIFF
--- a/app/services/hmac.py
+++ b/app/services/hmac.py
@@ -5,7 +5,7 @@ import hmac
 import hashlib
 
 
-def verifyHmac(sig_header: str, body: bytes, secret: str) -> bool:
+def verify_hmac(sig_header: str, body: bytes, secret: str) -> bool:
     """Return ``True`` if HMAC-SHA256 signature matches the body."""
     if not sig_header:
         return False

--- a/tests/test_hmac_util.py
+++ b/tests/test_hmac_util.py
@@ -1,4 +1,4 @@
-from app.services.hmac import verifyHmac
+from app.services.hmac import verify_hmac
 import hmac
 import hashlib
 
@@ -7,12 +7,12 @@ def test_verify_hmac_success():
     body = b'{"ok":true}'
     secret = 'test-hmac-secret'
     sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    assert verifyHmac(sig, body, secret)
+    assert verify_hmac(sig, body, secret)
 
 
 def test_verify_hmac_fail():
     body = b'{"ok":true}'
     secret = 'test-hmac-secret'
     sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    assert not verifyHmac('bad' + sig[3:], body, secret)
+    assert not verify_hmac('bad' + sig[3:], body, secret)
 


### PR DESCRIPTION
## Summary
- rename webhook HMAC verifier to `verify_hmac`
- update imports and usage across controller and tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2b2cbe68832aa2633d51c08b153d