### PR TITLE
fix: handle SBP HTTP errors

### DIFF
--- a/app/services/sbp.py
+++ b/app/services/sbp.py
@@ -1,6 +1,10 @@
 import os
+import logging
 
 import httpx
+
+
+logger = logging.getLogger(__name__)
 
 
 def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
@@ -26,5 +30,6 @@ def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
         resp.raise_for_status()
         data = resp.json()
         return data.get("url", f"https://sbp.example/pay/{external_id}")
-    except Exception:
+    except httpx.HTTPError as exc:
+        logger.error("SBP API request failed: %s", exc)
         return f"https://sbp.example/pay/{external_id}"

--- a/tests/test_sbp.py
+++ b/tests/test_sbp.py
@@ -1,0 +1,19 @@
+import httpx
+
+from app.services.sbp import create_sbp_link
+
+
+def test_create_sbp_link_handles_http_error(monkeypatch, caplog):
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("SBP_API_URL", "https://example.test")
+
+    def fake_post(*args, **kwargs):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    with caplog.at_level("ERROR"):
+        url = create_sbp_link("123", 100, "RUB")
+
+    assert url == "https://sbp.example/pay/123"
+    assert "boom" in caplog.text


### PR DESCRIPTION
## Summary
- narrow SBP error handling to httpx.HTTPError and log failures
- add tests for SBP error fallback

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2e1bf614832ab776a0698df7fbca