### PR TITLE
fix: avoid scheduling duplicate retry jobs

### DIFF
--- a/worker/retry_diagnosis.js
+++ b/worker/retry_diagnosis.js
@@ -17,10 +17,16 @@ const RETRY_LIMIT = parseInt(process.env.RETRY_LIMIT || '3', 10);
 console.log(`Retry diagnosis worker concurrency=${RETRY_CONCURRENCY}`);
 
 async function schedule() {
+  const jobs = await queue.getRepeatableJobs();
+  const alreadyScheduled = jobs.some((job) => job.id === 'retry');
+  if (alreadyScheduled) {
+    return;
+  }
   await queue.add(
     'retry',
     {},
     {
+      jobId: 'retry',
       repeat: { cron: retryCron, tz: 'Europe/Moscow' },
       removeOnComplete: true,
     }


### PR DESCRIPTION
## Summary
- ensure retry diagnosis worker schedules a single repeatable job

## Testing
- `ruff check app tests`
- `pytest`
- `npm ci --prefix bot`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e31d6d434832abe892e32ba88f1d1