### PR TITLE
fix: dedupe usage reset job

### DIFF
--- a/worker/usage_reset.js
+++ b/worker/usage_reset.js
@@ -10,10 +10,18 @@ const queue = new Queue(queueName, { connection });
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 async function schedule() {
+  const jobs = await queue.getRepeatableJobs();
+  const alreadyScheduled = jobs.some((job) => job.id === 'reset');
+  if (alreadyScheduled) {
+    console.log('Usage reset job already scheduled');
+    return;
+  }
+
   await queue.add(
     'reset',
     {},
     {
+      jobId: 'reset',
       repeat: { cron: '5 0 1 * *', tz: 'Europe/Moscow' },
       removeOnComplete: true,
     }


### PR DESCRIPTION
## Summary
- avoid scheduling duplicate usage reset jobs by checking existing repeatables
- assign fixed jobId when scheduling

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e3646f154832ab3f8eceb1e1878d0