### PR TITLE
chore: remove unused path import

### DIFF
--- a/fastify/index.js
+++ b/fastify/index.js
@@ -3,7 +3,6 @@ const Fastify = require('fastify');
 const fastifyMultipart = require('@fastify/multipart');
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 const { Pool } = require('pg');
-const path = require('path');
 
 const app = Fastify({ logger: true });
 app.register(fastifyMultipart);


### PR DESCRIPTION
## Summary
- remove unused path import from fastify server entry

## Testing
- `ruff check app tests`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e37c8eed0832a9ec89892afa7f41f