### PR TITLE
fix: replace all placeholders in msg

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -16,6 +16,7 @@ const {
 const { startHandler, helpHandler, feedbackHandler } = require('./commands');
 const { historyHandler } = require('./history');
 const strings = require('../locales/ru.json');
+const { msg } = require('./utils');
 function tr(key, vars = {}) {
   let text = strings[key];
   for (const [k, v] of Object.entries(vars)) {
@@ -464,4 +465,11 @@ test('formatDiagnosis omits button when disabled', () => {
   const { text, keyboard } = formatDiagnosis(ctx, data);
   assert.ok(text.includes('Культура: pear'));
   assert.equal(keyboard, undefined);
+});
+
+test('msg replaces multiple occurrences of a variable', () => {
+  strings.repeat = '{word} and {word}';
+  const result = msg('repeat', { word: 'hi' });
+  assert.equal(result, 'hi and hi');
+  delete strings.repeat;
 });

--- a/bot/utils.js
+++ b/bot/utils.js
@@ -3,7 +3,7 @@ const strings = require('../locales/ru.json');
 function msg(key, vars = {}) {
   let text = strings[key] || '';
   for (const [k, v] of Object.entries(vars)) {
-    text = text.replace(`{${k}}`, v);
+    text = text.replaceAll(`{${k}}`, v);
   }
   return text;
 }


### PR DESCRIPTION
## Summary
- ensure msg utility replaces all placeholder occurrences
- add test covering repeated placeholders

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e39d540c4832aa7c725a836685fba