### PR TITLE
fix: await logEvent in payment handlers

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -29,7 +29,9 @@ bot.start(async (ctx) => {
   await bot.telegram.setChatMenuButton(ctx.chat.id, { type: 'commands' });
 });
 
-bot.command('subscribe', (ctx) => subscribeHandler(ctx, pool));
+bot.command('subscribe', async (ctx) => {
+  await subscribeHandler(ctx, pool);
+});
 
 bot.command('help', (ctx) => helpHandler(ctx));
 
@@ -79,7 +81,9 @@ bot.action(/^info\|/, (ctx) => {
   return retryHandler(ctx, id);
 });
 
-bot.action('buy_pro', (ctx) => buyProHandler(ctx, pool));
+bot.action('buy_pro', async (ctx) => {
+  await buyProHandler(ctx, pool);
+});
 
 bot.launch().then(() => console.log('Bot started'));
 

--- a/bot/payments.js
+++ b/bot/payments.js
@@ -21,12 +21,12 @@ async function logEvent(pool, userId, ev) {
   }
 }
 
-function sendPaywall(ctx, pool) {
+async function sendPaywall(ctx, pool) {
   if (!paywallEnabled()) {
     return;
   }
   if (ctx.from) {
-    logEvent(pool, ctx.from.id, 'paywall_shown');
+    await logEvent(pool, ctx.from.id, 'paywall_shown');
   }
   const limit = getLimit();
   return ctx.reply(msg('paywall', { limit }), {
@@ -44,7 +44,7 @@ function sendPaywall(ctx, pool) {
 async function buyProHandler(ctx, pool, intervalMs = 3000) {
   ctx.answerCbQuery();
   if (ctx.from) {
-    logEvent(pool, ctx.from.id, 'paywall_click_buy');
+    await logEvent(pool, ctx.from.id, 'paywall_click_buy');
   }
   try {
     const resp = await fetch(`${API_BASE}/v1/payments/create`, {
@@ -103,7 +103,7 @@ async function pollPaymentStatus(ctx, paymentId, intervalMs = 3000) {
   }
 }
 
-function subscribeHandler(ctx, pool) {
+async function subscribeHandler(ctx, pool) {
   return sendPaywall(ctx, pool);
 }
 


### PR DESCRIPTION
## Summary
- await logEvent inside paywall helpers and make sendPaywall async
- await payment helpers in bot command and action handlers

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3c927098832a9b7ec9697a76d9f2