### PR TITLE
refactor: make SBP link creation async

### DIFF
--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -440,7 +440,7 @@ async def create_payment(body: PaymentCreateRequest, _: None = Depends(require_a
     amount = 19900 * body.months
     currency = "RUB"
     external_id = uuid4().hex
-    url = create_sbp_link(external_id, amount, currency)
+    url = await create_sbp_link(external_id, amount, currency)
 
     def _db_call() -> None:
         with db_module.SessionLocal() as db:

--- a/app/services/sbp.py
+++ b/app/services/sbp.py
@@ -7,7 +7,7 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
-def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
+async def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
     """Return SBP payment URL.
 
     In development returns a sandbox link. In production sends a request
@@ -26,9 +26,12 @@ def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
     }
     headers = {"Authorization": f"Bearer {token}"} if token else None
     try:
-        resp = httpx.post(api_url, json=payload, headers=headers, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                api_url, json=payload, headers=headers, timeout=10
+            )
+            resp.raise_for_status()
+            data = resp.json()
         return data.get("url", f"https://sbp.example/pay/{external_id}")
     except httpx.HTTPError as exc:
         logger.error("SBP API request failed: %s", exc)

--- a/tests/test_sbp.py
+++ b/tests/test_sbp.py
@@ -1,19 +1,46 @@
+import asyncio
+import time
+
 import httpx
+import pytest
 
 from app.services.sbp import create_sbp_link
 
 
-def test_create_sbp_link_handles_http_error(monkeypatch, caplog):
+@pytest.mark.asyncio
+async def test_create_sbp_link_handles_http_error(monkeypatch, caplog):
     monkeypatch.setenv("APP_ENV", "production")
     monkeypatch.setenv("SBP_API_URL", "https://example.test")
 
-    def fake_post(*args, **kwargs):
+    async def fake_post(self, *args, **kwargs):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
 
     with caplog.at_level("ERROR"):
-        url = create_sbp_link("123", 100, "RUB")
+        url = await create_sbp_link("123", 100, "RUB")
 
     assert url == "https://sbp.example/pay/123"
     assert "boom" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_create_sbp_link_non_blocking(monkeypatch):
+    """create_sbp_link should not block the event loop."""
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("SBP_API_URL", "https://example.test")
+
+    async def fake_post(self, *args, **kwargs):
+        await asyncio.sleep(0.1)
+        request = httpx.Request("POST", "https://example.test")
+        return httpx.Response(200, json={"url": "https://sbp.example/pay/123"}, request=request)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    start = time.perf_counter()
+    await asyncio.gather(
+        create_sbp_link("123", 100, "RUB"),
+        asyncio.sleep(0.1),
+    )
+    duration = time.perf_counter() - start
+    assert duration < 0.2


### PR DESCRIPTION
## Summary
- refactor SBP payment link generator to use async httpx client
- await SBP link creation in payment controller
- add async tests ensuring SBP helper doesn't block the event loop

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e4108c880832a9296ffbe14cac06a