### PR TITLE
fix: validate JSON payload in HMAC verifier

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -49,6 +49,9 @@ async def verify_hmac(request: Request, x_sign: str):
     except Exception as err:
         raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
 
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="BAD_REQUEST")
+
     provided_sign = payload.get("signature")
     if not provided_sign:
         raise HTTPException(status_code=400, detail="BAD_REQUEST")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -586,6 +586,20 @@ async def test_verify_hmac_bad_payload_signature(client):
     assert exc.value.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_verify_hmac_bad_json(client):
+    payload = [1, 2, 3]
+    body = json.dumps(payload).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request({"type": "http"}, receive)
+    with pytest.raises(HTTPException) as exc:
+        await verify_hmac(request, "sig")
+    assert exc.value.status_code == 400
+
+
 def test_payment_webhook_missing_signature(client):
     payload = {
         "external_id": "1",


### PR DESCRIPTION
## Summary
- ensure `verify_hmac` rejects JSON payloads that aren't objects
- add test covering invalid JSON payloads

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e427a39f0832a9f06192c1c432636