### PR TITLE
[fix] validate user id on payment creation

### DIFF
--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -433,7 +433,11 @@ async def get_limits(user_id: int = Depends(require_api_headers)):
     response_model=PaymentCreateResponse,
     responses={401: {"model": ErrorResponse}},
 )
-async def create_payment(body: PaymentCreateRequest, _: None = Depends(require_api_headers)):
+async def create_payment(body: PaymentCreateRequest, user_id: int = Depends(require_api_headers)):
+    if body.user_id != user_id:
+        err = ErrorResponse(code="UNAUTHORIZED", message="User ID mismatch")
+        raise HTTPException(status_code=401, detail=err.model_dump())
+
     if body.plan.lower() != "pro":
         raise HTTPException(status_code=400, detail="BAD_REQUEST")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -403,6 +403,12 @@ def test_create_payment(client):
         assert event.event == "payment_created"
 
 
+def test_create_payment_user_id_mismatch(client):
+    payload = {"user_id": 2, "plan": "pro", "months": 1}
+    resp = client.post("/v1/payments/create", headers=HEADERS, json=payload)
+    assert resp.status_code == 401
+
+
 def test_payment_webhook_success(client):
     from app.db import SessionLocal
     from app.models import Payment, Event


### PR DESCRIPTION
## Summary
- validate that payment creation uses authenticated user id
- add regression test for mismatched user id

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e43de8760832aa270efcdb73beb73