### PR TITLE
fix: increment usage only on valid image

### DIFF
--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -198,21 +198,6 @@ async def diagnose(
 
         return await asyncio.to_thread(_db)
 
-    used, pro = await _increment_usage()
-    now_utc = datetime.now(timezone.utc)
-    if PAYWALL_ENABLED and used > FREE_MONTHLY_LIMIT and (not pro or pro < now_utc):
-        if pro and pro < now_utc:
-            def _log() -> None:
-                with db_module.SessionLocal() as db:
-                    db.add(Event(user_id=user_id, event="pro_expired"))
-                    db.commit()
-
-            await asyncio.to_thread(_log)
-        return JSONResponse(
-            status_code=402,
-            content={"error": "limit_reached", "limit": FREE_MONTHLY_LIMIT},
-        )
-
     status = "ok"
     file_id = ""
     crop = ""
@@ -227,6 +212,22 @@ async def diagnose(
         if len(contents) > 2 * 1024 * 1024:
             err = ErrorResponse(code="BAD_REQUEST", message="image too large")
             return JSONResponse(status_code=400, content=err.model_dump())
+
+        used, pro = await _increment_usage()
+        now_utc = datetime.now(timezone.utc)
+        if PAYWALL_ENABLED and used > FREE_MONTHLY_LIMIT and (not pro or pro < now_utc):
+            if pro and pro < now_utc:
+                def _log() -> None:
+                    with db_module.SessionLocal() as db:
+                        db.add(Event(user_id=user_id, event="pro_expired"))
+                        db.commit()
+
+                await asyncio.to_thread(_log)
+            return JSONResponse(
+                status_code=402,
+                content={"error": "limit_reached", "limit": FREE_MONTHLY_LIMIT},
+            )
+
         key = await upload_photo(user_id, contents)
         file_id = key
         try:
@@ -261,6 +262,22 @@ async def diagnose(
         if len(contents) > 2 * 1024 * 1024:
             err = ErrorResponse(code="BAD_REQUEST", message="image too large")
             return JSONResponse(status_code=400, content=err.model_dump())
+
+        used, pro = await _increment_usage()
+        now_utc = datetime.now(timezone.utc)
+        if PAYWALL_ENABLED and used > FREE_MONTHLY_LIMIT and (not pro or pro < now_utc):
+            if pro and pro < now_utc:
+                def _log() -> None:
+                    with db_module.SessionLocal() as db:
+                        db.add(Event(user_id=user_id, event="pro_expired"))
+                        db.commit()
+
+                await asyncio.to_thread(_log)
+            return JSONResponse(
+                status_code=402,
+                content={"error": "limit_reached", "limit": FREE_MONTHLY_LIMIT},
+            )
+
         key = await upload_photo(user_id, contents)
         file_id = key
         try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,6 +161,10 @@ def test_diagnose_without_protocol(client):
 
 
 def test_diagnose_json_bad_prompt(client):
+    before = client.get("/v1/limits", headers=HEADERS)
+    assert before.status_code == 200
+    used_before = before.json()["used_this_month"]
+
     resp = client.post(
         "/v1/ai/diagnose",
         headers=HEADERS,
@@ -170,6 +174,10 @@ def test_diagnose_json_bad_prompt(client):
     data = resp.json()
     assert data["code"] == "BAD_REQUEST"
     assert "prompt_id" in data["message"]
+
+    after = client.get("/v1/limits", headers=HEADERS)
+    assert after.status_code == 200
+    assert after.json()["used_this_month"] == used_before
 
 
 def test_diagnose_json_missing_prompt(client):
@@ -185,12 +193,20 @@ def test_diagnose_json_missing_prompt(client):
 
 
 def test_diagnose_invalid_base64(client):
+    before = client.get("/v1/limits", headers=HEADERS)
+    assert before.status_code == 200
+    used_before = before.json()["used_this_month"]
+
     resp = client.post(
         "/v1/ai/diagnose",
         headers=HEADERS,
         json={"image_base64": "dGVzdA==@@", "prompt_id": "v1"},
     )
     assert resp.status_code == 400
+
+    after = client.get("/v1/limits", headers=HEADERS)
+    assert after.status_code == 200
+    assert after.json()["used_this_month"] == used_before
 
 
 def test_diagnose_multipart_missing_image(client):


### PR DESCRIPTION
## Summary
- increment user quota only after an image is successfully decoded
- ensure invalid diagnose requests do not consume usage
- test that validation errors keep monthly usage unchanged

## Testing
- `ruff check app tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e44e84b28832a9f9a1205d2a44633