### PR TITLE
fix(bot): send payment data in POST body

### DIFF
--- a/bot/payments.js
+++ b/bot/payments.js
@@ -53,7 +53,9 @@ async function buyProHandler(ctx, pool, intervalMs = 3000) {
         'X-API-Key': API_KEY,
         'X-API-Ver': API_VER,
         'X-User-ID': ctx.from?.id,
+        'Content-Type': 'application/json',
       },
+      body: JSON.stringify({ user_id: ctx.from.id, plan: 'pro', months: 1 }),
     });
     const data = await resp.json();
     ctx.paymentId = data.payment_id;


### PR DESCRIPTION
## Summary
- include JSON body and Content-Type header in payment creation request
- extend buyProHandler tests to verify POST payload and headers

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e465221e4832ab40dc8810d03ac16