### PR TITLE
fix: await history events

### DIFF
--- a/bot/history.js
+++ b/bot/history.js
@@ -8,9 +8,17 @@ const API_VER = process.env.API_VER || 'v1';
 async function historyHandler(ctx, offset = 0, pool) {
   if (ctx.from && pool) {
     if (offset === 0) {
-      logEvent(pool, ctx.from.id, 'history_open');
+      try {
+        await logEvent(pool, ctx.from.id, 'history_open');
+      } catch (err) {
+        console.error('logEvent history_open error', err);
+      }
     }
-    logEvent(pool, ctx.from.id, `history_page_${offset}`);
+    try {
+      await logEvent(pool, ctx.from.id, `history_page_${offset}`);
+    } catch (err) {
+      console.error('logEvent history_page error', err);
+    }
   }
   const resp = await fetch(
     `${API_BASE}/v1/photos/history?limit=10&offset=${offset}`,

--- a/bot/index.js
+++ b/bot/index.js
@@ -35,7 +35,7 @@ bot.command('subscribe', async (ctx) => {
 
 bot.command('help', (ctx) => helpHandler(ctx));
 
-bot.command('history', (ctx) => historyHandler(ctx, 0, pool));
+bot.command('history', async (ctx) => historyHandler(ctx, 0, pool));
 
 bot.on('photo', (ctx) => photoHandler(pool, ctx));
 


### PR DESCRIPTION
## Summary
- await `logEvent` calls and log errors in history handler
- make `/history` command handler async

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e4e6a25c4832a94157a74497fb6cc