### PR TITLE
[fix] include retrying status in retry worker

### DIFF
--- a/worker/retry_diagnosis.js
+++ b/worker/retry_diagnosis.js
@@ -43,7 +43,7 @@ new Worker(
     let success = 0;
     let failed = 0;
     try {
-      const { rows } = await client.query("SELECT id, file_id FROM photos WHERE status='pending'");
+      const { rows } = await client.query("SELECT id, file_id FROM photos WHERE status IN ('pending','retrying')");
       processed = rows.length;
       for (const row of rows) {
         try {


### PR DESCRIPTION
## Summary
- include retrying status when selecting photos for retry diagnosis

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e509c2854832a8df864b0326f336a