### PR TITLE
[fix] handle SBP JSON parse errors

### DIFF
--- a/app/services/sbp.py
+++ b/app/services/sbp.py
@@ -36,3 +36,6 @@ async def create_sbp_link(external_id: str, amount: int, currency: str) -> str:
     except httpx.HTTPError as exc:
         logger.error("SBP API request failed: %s", exc)
         return f"https://sbp.example/pay/{external_id}"
+    except ValueError as exc:
+        logger.error("SBP API response parsing failed: %s", exc)
+        return f"https://sbp.example/pay/{external_id}"


### PR DESCRIPTION
## Summary
- handle SBP API JSON parsing failures by logging and returning fallback URL

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e59502dd8832ab1f475a654c12ade