### PR TITLE
fix: handle invalid JSON in payment webhook

### DIFF
--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -525,7 +525,8 @@ async def payments_webhook(
 
     try:
         data = json.loads(raw_body)
-    except Exception as err:
+    except (json.JSONDecodeError, TypeError) as err:
+        logger.exception("failed to parse webhook body as JSON")
         raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
     provided_sign = data.pop("signature", "")
 


### PR DESCRIPTION
## Summary
- handle invalid JSON in payment webhook

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e605c2bec832a8ae26d129e23a2f2