### PR TITLE
fix: handle errors in history fetch

### DIFF
--- a/bot/history.js
+++ b/bot/history.js
@@ -20,40 +20,45 @@ async function historyHandler(ctx, offset = 0, pool) {
       console.error('logEvent history_page error', err);
     }
   }
-  const resp = await fetch(
-    `${API_BASE}/v1/photos/history?limit=10&offset=${offset}`,
-    {
-      headers: {
-        'X-API-Key': API_KEY,
-        'X-API-Ver': API_VER,
-        'X-User-ID': ctx.from?.id,
+  try {
+    const resp = await fetch(
+      `${API_BASE}/v1/photos/history?limit=10&offset=${offset}`,
+      {
+        headers: {
+          'X-API-Key': API_KEY,
+          'X-API-Ver': API_VER,
+          'X-User-ID': ctx.from?.id,
+        },
       },
-    },
-  );
-  if (!resp.ok) {
+    );
+    if (!resp.ok) {
+      await ctx.reply(msg('history_error'));
+      return;
+    }
+    const data = await resp.json();
+    if (!Array.isArray(data)) {
+      console.error('Unexpected history response', data);
+      await ctx.reply(msg('history_error'));
+      return;
+    }
+    let text = data
+      .map((it, idx) => {
+        const dt = new Date(it.ts);
+        const date = dt.toLocaleDateString('ru-RU');
+        return `${idx + offset + 1}. ${date}, ${it.crop}, ${it.disease}, ${it.status}`;
+      })
+      .join('\n');
+    if (!text) text = msg('history_empty');
+    const keyboard = data.map((it) => [{ text: 'ℹ️', callback_data: `info|${it.photo_id}` }]);
+    keyboard.push([
+      { text: '◀️', callback_data: `history|${Math.max(offset - 10, 0)}` },
+      { text: '▶️', callback_data: `history|${offset + 10}` },
+    ]);
+    await ctx.reply(text, { reply_markup: { inline_keyboard: keyboard } });
+  } catch (err) {
+    console.error('history fetch error', err);
     await ctx.reply(msg('history_error'));
-    return;
   }
-  const data = await resp.json();
-  if (!Array.isArray(data)) {
-    console.error('Unexpected history response', data);
-    await ctx.reply(msg('history_error'));
-    return;
-  }
-  let text = data
-    .map((it, idx) => {
-      const dt = new Date(it.ts);
-      const date = dt.toLocaleDateString('ru-RU');
-      return `${idx + offset + 1}. ${date}, ${it.crop}, ${it.disease}, ${it.status}`;
-    })
-    .join('\n');
-  if (!text) text = msg('history_empty');
-  const keyboard = data.map((it) => [{ text: 'ℹ️', callback_data: `info|${it.photo_id}` }]);
-  keyboard.push([
-    { text: '◀️', callback_data: `history|${Math.max(offset - 10, 0)}` },
-    { text: '▶️', callback_data: `history|${offset + 10}` },
-  ]);
-  await ctx.reply(text, { reply_markup: { inline_keyboard: keyboard } });
 }
 
 module.exports = { historyHandler };


### PR DESCRIPTION
## Summary
- handle API errors in history handler

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e6317b070832aa01ca2f383e5734d