### PR TITLE
fix(bot): validate database URL

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -11,9 +11,12 @@ if (!token) {
   throw new Error('BOT_TOKEN_DEV not set');
 }
 
+const dbUrl = process.env.BOT_DATABASE_URL || process.env.DATABASE_URL;
+if (!dbUrl) {
+  throw new Error('DATABASE_URL not set');
+}
 const pool = new Pool({
-  connectionString:
-    process.env.BOT_DATABASE_URL || process.env.DATABASE_URL,
+  connectionString: dbUrl,
 });
 const bot = new Telegraf(token);
 


### PR DESCRIPTION
## Summary
- ensure bot throws a clear error when DATABASE_URL is missing
- use a consolidated dbUrl when initializing the Postgres pool

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688e69349754832aaa08d0f3c68b67d1