### PR TITLE
fix: handle bot launch errors

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -88,7 +88,12 @@ bot.action('buy_pro', async (ctx) => {
   await buyProHandler(ctx, pool);
 });
 
-bot.launch().then(() => console.log('Bot started'));
+bot.launch()
+  .then(() => console.log('Bot started'))
+  .catch((err) => {
+    console.error('Bot launch failed', err);
+    process.exit(1);
+  });
 
 // Gracefully close DB connections on termination
 async function shutdown() {


### PR DESCRIPTION
## Summary
- exit on bot launch failure for clearer debugging

## Testing
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_688e6a818d64832ab79e7bdc3b2245c8