### PR TITLE
fix: remove unused sendPaywall import

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -1,5 +1,5 @@
 const { msg } = require('./utils');
-const { logEvent, sendPaywall } = require('./payments');
+const { logEvent } = require('./payments');
 
 async function startHandler(ctx, pool) {
   if (ctx.startPayload === 'paywall') {


### PR DESCRIPTION
## Summary
- drop unused sendPaywall from commands import

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee1992f80832aa2892b23ba7c0560