### PR TITLE
[fix] simplify GPT error logging

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -183,8 +183,8 @@ async def diagnose(
             disease = result.get("disease", "")
             conf = result.get("confidence", 0.0)
             status = "ok"
-        except (TimeoutError, ValueError, json.JSONDecodeError) as exc:
-            logger.exception("GPT error", exc_info=exc)
+        except (TimeoutError, ValueError, json.JSONDecodeError):
+            logger.exception("GPT error")
             crop = ""
             disease = ""
             conf = 0.0
@@ -233,8 +233,8 @@ async def diagnose(
             disease = result.get("disease", "")
             conf = result.get("confidence", 0.0)
             status = "ok"
-        except (TimeoutError, ValueError, json.JSONDecodeError) as exc:
-            logger.exception("GPT error", exc_info=exc)
+        except (TimeoutError, ValueError, json.JSONDecodeError):
+            logger.exception("GPT error")
             crop = ""
             disease = ""
             conf = 0.0


### PR DESCRIPTION
## Summary
- simplify GPT error logging by relying on logger.exception default exc_info

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee2edf048832aa0920c68167dd8fc