### PR TITLE
fix: handle invalid phi values in protocol import

### DIFF
--- a/app/services/protocols.py
+++ b/app/services/protocols.py
@@ -78,13 +78,17 @@ def import_csv_to_db(path: Path = CSV_PATH, update: bool = False) -> None:
         if count == 0 and path.exists():
             rows = load_csv(path)
             for r in rows:
+                try:
+                    phi = int(r.get("phi") or 0)
+                except ValueError:
+                    phi = 0
                 proto = Protocol(
                     crop=r["crop"],
                     disease=r["disease"],
                     product=r["product"],
                     dosage_value=r["dosage_value"],
                     dosage_unit=r["dosage_unit"],
-                    phi=int(r["phi"]),
+                    phi=phi,
                 )
                 session.add(proto)
             session.commit()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -17,6 +17,44 @@ def test_import_csv_no_table():
         import_csv_to_db()
 
 
+def test_import_csv_invalid_phi(tmp_path):
+    """Import CSV rows with empty or invalid phi values."""
+
+    csv_file = tmp_path / "protocols.csv"
+    csv_file.write_text(
+        "crop,disease,product,dosage_value,dosage_unit,phi\n"
+        "cucumber,mildew,Prod1,1,l_per_ha,\n"
+        "wheat,rust,Prod2,2,l_per_ha,abc\n",
+        encoding="utf-8",
+    )
+
+    with SessionLocal() as session:
+        session.query(Protocol).delete()
+        session.commit()
+
+    import_csv_to_db(path=csv_file)
+
+    try:
+        with SessionLocal() as session:
+            r1 = (
+                session.query(Protocol)
+                .filter(Protocol.crop == "cucumber", Protocol.disease == "mildew")
+                .one()
+            )
+            r2 = (
+                session.query(Protocol)
+                .filter(Protocol.crop == "wheat", Protocol.disease == "rust")
+                .one()
+            )
+            assert r1.phi == 0
+            assert r2.phi == 0
+    finally:
+        with SessionLocal() as session:
+            session.query(Protocol).delete()
+            session.commit()
+        import_csv_to_db()
+
+
 def test_find_protocol_found():
 
     import_csv_to_db()


### PR DESCRIPTION
## Summary
- handle missing or invalid `phi` values when importing protocols
- cover import of empty or malformed `phi` fields with regression test

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688ee433c71c832a95e43cc15a38bb86