### PR TITLE
fix: await payment reply before polling

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -315,7 +315,6 @@ test('buyProHandler returns payment link', { concurrency: false }, async () => {
     async () => {
       await buyProHandler(ctx, pool, 0);
       if (ctx.pollPromise) await ctx.pollPromise;
-      await new Promise((r) => setTimeout(r, 20));
     },
     calls,
   );

--- a/bot/payments.js
+++ b/bot/payments.js
@@ -59,7 +59,7 @@ async function buyProHandler(ctx, pool, intervalMs = 3000, timeoutMs = 60000) {
     });
     const data = await resp.json();
     ctx.paymentId = data.payment_id;
-    const reply = ctx.reply(msg('payment_prompt'), {
+    const reply = await ctx.reply(msg('payment_prompt'), {
       reply_markup: {
         inline_keyboard: [[{ text: msg('payment_button'), url: data.url }]],
       },
@@ -72,7 +72,7 @@ async function buyProHandler(ctx, pool, intervalMs = 3000, timeoutMs = 60000) {
     return reply;
   } catch (err) {
     console.error('payment error', err);
-    return ctx.reply(msg('payment_error'));
+    return await ctx.reply(msg('payment_error'));
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure payment prompt is sent before polling payment status
- await error replies for payment failures
- adjust payment handler test for awaited reply

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688eef3c1800832a93e3e42968f55900