### PR TITLE
fix: handle photo download errors in diagnosis

### DIFF
--- a/bot/diagnosis.js
+++ b/bot/diagnosis.js
@@ -78,6 +78,13 @@ async function photoHandler(pool, ctx) {
     const link = await ctx.telegram.getFileLink(file_id);
     console.log('Downloading photo from', link.href);
     const res = await fetch(link.href);
+    if (!res.ok) {
+      console.error('Photo download error', res.status);
+      if (typeof ctx.reply === 'function') {
+        await ctx.reply(msg('diagnose_error'));
+      }
+      return;
+    }
     const buffer = Buffer.from(await res.arrayBuffer());
     const form = new FormData();
     form.append('image', new Blob([buffer], { type: 'image/jpeg' }), 'photo.jpg');


### PR DESCRIPTION
## Summary
- check photo download response before processing and notify user on failure

## Testing
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_688ef80eaa48832a967a79ff0c750f4a