### PR TITLE
fix(bot): await graceful shutdown

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -105,14 +105,19 @@ async function init() {
 
 init();
 
-// Gracefully close DB connections on termination
+// Gracefully stop bot and close DB connections on termination
 async function shutdown() {
+  await bot.stop();
   await pool.end();
   process.exit(0);
 }
 
-process.once('SIGINT', shutdown);
-process.once('SIGTERM', shutdown);
+process.once('SIGINT', async () => {
+  await shutdown();
+});
+process.once('SIGTERM', async () => {
+  await shutdown();
+});
 
 // Prometheus метрики
 const client = require('prom-client');


### PR DESCRIPTION
## Summary
- ensure bot.stop is awaited so Telegraf sessions close cleanly
- await shutdown in SIGINT and SIGTERM handlers

## Testing
- `npm ci --prefix bot`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688f037c5818832a83fe948440eccab4