### PR TITLE
feat: add partner HMAC and Tinkoff creds

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -47,6 +47,7 @@ APP_ENV=development   # development / production / staging
 # 🔒 Security / HMAC / JWT
 # =======================
 HMAC_SECRET=test-hmac-secret
+HMAC_SECRET_PARTNER=test-hmac-partner
 # JWT_SECRET=your-jwt-secret (если используется JWT)
 # ALLOWED_ORIGINS=http://localhost:3000 (если нужен CORS)
 
@@ -71,6 +72,8 @@ S3_PUBLIC_URL=http://localhost:9000
 # =========================
 # 🧪 External Integrations
 # =========================
+TINKOFF_TERMINAL_KEY=your-terminal-key
+TINKOFF_SECRET_KEY=your-secret-key
 # AGROSTORE_API_KEY=your-agrostore-api-key-here
 # PARTNER_WEBHOOK_SECRET=partner-secret
 # PARTNER_LINK_BASE=https://agrostore.ru/agronom

--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ agronom-bot/
    - `PARTNER_LINK_BASE=https://agrostore.ru/agronom`
    - `PAYWALL_ENABLED=true`  # включить показ paywall
    - `BOT_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom`  # строка подключения для бота
-   - `FREE_PHOTO_LIMIT=5`  # число бесплатных фото в месяц для Telegram-бота ([пример](.env.template#L86))
+   - `FREE_PHOTO_LIMIT=5`  # число бесплатных фото в месяц для Telegram-бота ([пример](.env.template#L89))
+   - `TINKOFF_TERMINAL_KEY=your-terminal-key`
+   - `TINKOFF_SECRET_KEY=your-secret-key`
+   - `HMAC_SECRET_PARTNER=test-hmac-partner`  # подпись AgroStore
 
   Бот подключается к PostgreSQL по DSN из `BOT_DATABASE_URL`.
 

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,9 @@ class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
     hmac_secret: str = "test-hmac-secret"
+    hmac_secret_partner: str = "test-hmac-partner"
+    tinkoff_terminal_key: str = "tinkoff-terminal-key"
+    tinkoff_secret_key: str = "tinkoff-secret-key"
     free_monthly_limit: int = 5
     paywall_enabled: bool = Field(True, alias="PAYWALL_ENABLED")
 

--- a/app/controllers/partners.py
+++ b/app/controllers/partners.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 from app import db as db_module
-from app.dependencies import ErrorResponse, require_api_headers, verify_hmac as verify_request_hmac
+from app.dependencies import ErrorResponse, require_api_headers, verify_hmac as verify_partner_hmac
 from app.models import PartnerOrder
 
 router = APIRouter(prefix="/partner")
@@ -28,7 +28,7 @@ async def partner_orders(
     _: None = Depends(require_api_headers),
     x_sign: str = Header(..., alias="X-Sign"),
 ):
-    data, sign, provided_sign = await verify_request_hmac(request, x_sign)
+    data, sign, provided_sign = await verify_partner_hmac(request, x_sign)
     try:
         body = PartnerOrderRequest(**data, signature=provided_sign)
     except ValidationError as err:

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from app.config import Settings
 
 settings = Settings()
-HMAC_SECRET = settings.hmac_secret
+HMAC_SECRET_PARTNER = settings.hmac_secret_partner
 
 
 class ErrorResponse(BaseModel):
@@ -60,7 +60,7 @@ async def verify_hmac(request: Request, x_sign: str):
         raise HTTPException(status_code=400, detail=err.model_dump())
 
     payload.pop("signature", None)
-    calculated = compute_signature(HMAC_SECRET, payload)
+    calculated = compute_signature(HMAC_SECRET_PARTNER, payload)
 
     if not hmac.compare_digest(calculated, x_sign) or not hmac.compare_digest(
         calculated, provided_sign


### PR DESCRIPTION
## Summary
- add Tinkoff and partner HMAC secrets to env template and settings
- verify partner requests with dedicated HMAC secret
- document new env vars in README

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f91cd0874832a83121eb1d090bbf6