### PR TITLE
feat: add user dsr export and delete

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -1,0 +1,107 @@
+import asyncio
+import hmac
+import io
+import json
+import zipfile
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from app import db as db_module
+from app.config import Settings
+from app.dependencies import ErrorResponse, compute_signature, require_api_headers
+from app.models import Event, Payment, Photo, User
+
+settings = Settings()
+HMAC_SECRET = settings.hmac_secret
+
+router = APIRouter()
+
+
+@router.get(
+    "/users/{user_id}/export",
+    responses={401: {"model": ErrorResponse}, 403: {"model": ErrorResponse}},
+)
+async def export_user(
+    user_id: int,
+    x_sign: str = Header(..., alias="X-Sign"),
+    auth_user: int = Depends(require_api_headers),
+):
+    payload = {"user_id": user_id}
+    expected_sign = compute_signature(HMAC_SECRET, payload)
+    if not hmac.compare_digest(expected_sign, x_sign):
+        err = ErrorResponse(code="UNAUTHORIZED", message="Invalid signature")
+        raise HTTPException(status_code=401, detail=err.model_dump())
+    if auth_user != user_id:
+        err = ErrorResponse(code="FORBIDDEN", message="Cannot access other user")
+        raise HTTPException(status_code=403, detail=err.model_dump())
+
+    def _db_call() -> dict:
+        with db_module.SessionLocal() as db:
+            photos = db.query(Photo).filter_by(user_id=user_id).all()
+            payments = db.query(Payment).filter_by(user_id=user_id).all()
+            events = db.query(Event).filter_by(user_id=user_id).all()
+
+            def serialize(items):
+                return [
+                    {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+                    for obj in items
+                ]
+
+            return {
+                "photos": serialize(photos),
+                "payments": serialize(payments),
+                "events": serialize(events),
+            }
+
+    data = await asyncio.to_thread(_db_call)
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("data.json", json.dumps(data, default=str))
+    buffer.seek(0)
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="user_{user_id}_export.zip"'
+    }
+    return StreamingResponse(buffer, media_type="application/zip", headers=headers)
+
+
+@router.post(
+    "/dsr/delete_user",
+    responses={401: {"model": ErrorResponse}, 403: {"model": ErrorResponse}},
+)
+async def delete_user(
+    request: Request,
+    x_sign: str = Header(..., alias="X-Sign"),
+    auth_user: int = Depends(require_api_headers),
+):
+    try:
+        payload = await request.json()
+    except Exception as err:  # noqa: BLE001
+        err_resp = ErrorResponse(code="BAD_REQUEST", message="Invalid JSON")
+        raise HTTPException(status_code=400, detail=err_resp.model_dump()) from err
+
+    user_id = payload.get("user_id")
+    if user_id is None:
+        err_resp = ErrorResponse(code="BAD_REQUEST", message="Missing user_id")
+        raise HTTPException(status_code=400, detail=err_resp.model_dump())
+
+    expected_sign = compute_signature(HMAC_SECRET, {"user_id": user_id})
+    if not hmac.compare_digest(expected_sign, x_sign):
+        err = ErrorResponse(code="UNAUTHORIZED", message="Invalid signature")
+        raise HTTPException(status_code=401, detail=err.model_dump())
+
+    if user_id != auth_user:
+        err = ErrorResponse(code="FORBIDDEN", message="Cannot delete other user")
+        raise HTTPException(status_code=403, detail=err.model_dump())
+
+    def _db_delete() -> None:
+        with db_module.SessionLocal() as db:
+            db.query(Photo).filter_by(user_id=user_id).delete()
+            db.query(Payment).filter_by(user_id=user_id).delete()
+            db.query(Event).filter_by(user_id=user_id).delete()
+            db.query(User).filter_by(id=user_id).delete()
+            db.commit()
+
+    await asyncio.to_thread(_db_delete)
+    return {"status": "deleted"}

--- a/app/controllers/v1.py
+++ b/app/controllers/v1.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import photos, payments, partners, experts
+from . import photos, payments, partners, experts, users
 
 router = APIRouter(prefix="/v1")
 router.include_router(photos.router)
@@ -8,3 +8,4 @@ router.include_router(photos.router)
 router.include_router(payments.router)
 router.include_router(partners.router)
 router.include_router(experts.router)
+router.include_router(users.router)

--- a/tests/test_users_dsr.py
+++ b/tests/test_users_dsr.py
@@ -1,0 +1,95 @@
+import io
+import json
+import zipfile
+
+from app.config import Settings
+from app.db import SessionLocal
+from app.dependencies import compute_signature
+from app.models import Event, Payment, Photo, User
+
+HEADERS = {
+    "X-API-Key": "test-api-key",
+    "X-API-Ver": "v1",
+    "X-User-ID": "1",
+}
+
+HMAC_SECRET = Settings().hmac_secret
+
+
+def _prepare_db():
+    with SessionLocal() as db:
+        db.query(Photo).filter_by(user_id=1).delete()
+        db.query(Payment).filter_by(user_id=1).delete()
+        db.query(Event).filter_by(user_id=1).delete()
+        db.query(User).filter_by(id=1).delete()
+        db.add(User(id=1, tg_id=1))
+        db.add(Photo(user_id=1, file_id="f1"))
+        db.add(
+            Payment(
+                user_id=1,
+                amount=100,
+                currency="RUB",
+                provider="test",
+                status="success",
+            )
+        )
+        db.add(Event(user_id=1, event="login"))
+        db.commit()
+
+
+def test_export_user_data(client):
+    _prepare_db()
+    sig = compute_signature(HMAC_SECRET, {"user_id": 1})
+    resp = client.get(
+        "/v1/users/1/export", headers=HEADERS | {"X-Sign": sig}
+    )
+    assert resp.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    data = json.loads(zf.read("data.json"))
+    assert len(data["photos"]) == 1
+    assert len(data["payments"]) == 1
+    assert len(data["events"]) == 1
+
+
+def test_export_bad_signature(client):
+    _prepare_db()
+    resp = client.get(
+        "/v1/users/1/export", headers=HEADERS | {"X-Sign": "bad"}
+    )
+    assert resp.status_code == 401
+
+
+def test_delete_user_cascade(client):
+    _prepare_db()
+    sig = compute_signature(HMAC_SECRET, {"user_id": 1})
+    resp = client.post(
+        "/v1/dsr/delete_user",
+        headers=HEADERS | {"X-Sign": sig},
+        json={"user_id": 1},
+    )
+    assert resp.status_code == 200
+    with SessionLocal() as db:
+        assert db.query(User).filter_by(id=1).first() is None
+        assert db.query(Photo).filter_by(user_id=1).count() == 0
+        assert db.query(Payment).filter_by(user_id=1).count() == 0
+        assert db.query(Event).filter_by(user_id=1).count() == 0
+
+
+def test_delete_user_bad_signature(client):
+    _prepare_db()
+    resp = client.post(
+        "/v1/dsr/delete_user",
+        headers=HEADERS | {"X-Sign": "bad"},
+        json={"user_id": 1},
+    )
+    assert resp.status_code == 401
+
+
+def test_delete_user_forbidden(client):
+    _prepare_db()
+    sig = compute_signature(HMAC_SECRET, {"user_id": 1})
+    headers = HEADERS | {"X-User-ID": "2", "X-Sign": sig}
+    resp = client.post(
+        "/v1/dsr/delete_user", headers=headers, json={"user_id": 1}
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add `/v1/users/{id}/export` endpoint returning a zip with photos, payments and events
- add `/v1/dsr/delete_user` with HMAC and cascade cleanup
- cover DSR export and delete flows with tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa0e4ec48832a8e6584315e372e43