### PR TITLE
feat: add redis rate limiting

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,6 +34,7 @@ POSTGRES_PORT=5432
 # Перед запуском миграций укажите эту переменную
 DATABASE_URL=sqlite:///./app.db
 BOT_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
+# Redis connection string for rate limiting and queues
 REDIS_URL=redis://localhost:6379
 
 # ==========================

--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,8 @@ class Settings(BaseSettings):
     database_url: str = Field("sqlite:///./app.db", alias="DATABASE_URL")
     db_create_all: bool = Field(False, alias="DB_CREATE_ALL")
 
+    redis_url: str = Field("redis://localhost:6379", alias="REDIS_URL")
+
     s3_bucket: str = "agronom"
     s3_endpoint: str | None = None
     s3_region: str = "us-east-1"

--- a/app/controllers/experts.py
+++ b/app/controllers/experts.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from app import db as db_module
-from app.dependencies import ErrorResponse, require_api_headers
+from app.dependencies import ErrorResponse, rate_limit
 from app.models import Event
 
 router = APIRouter()
@@ -20,7 +20,7 @@ class AskExpertRequest(BaseModel):
     responses={401: {"model": ErrorResponse}, 400: {"model": ErrorResponse}},
 )
 async def ask_expert(
-    body: AskExpertRequest, user_id: int = Depends(require_api_headers)
+    body: AskExpertRequest, user_id: int = Depends(rate_limit)
 ):
     """Queue a question for a human expert."""
 

--- a/app/controllers/partners.py
+++ b/app/controllers/partners.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ValidationError
 from app import db as db_module
 from app.dependencies import (
     ErrorResponse,
-    require_api_headers,
+    rate_limit,
     verify_partner_hmac,
 )
 from app.models import PartnerOrder
@@ -29,7 +29,7 @@ class PartnerOrderRequest(BaseModel):
 )
 async def partner_orders(
     request: Request,
-    _: None = Depends(require_api_headers),
+    _: None = Depends(rate_limit),
     x_sign: str = Header(..., alias="X-Sign"),
 ):
     data, sign, provided_sign = await verify_partner_hmac(request, x_sign)

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -8,7 +8,7 @@ from fastapi.responses import StreamingResponse
 
 from app import db as db_module
 from app.config import Settings
-from app.dependencies import ErrorResponse, compute_signature, require_api_headers
+from app.dependencies import ErrorResponse, compute_signature, rate_limit
 from app.models import Event, Payment, Photo, User
 
 settings = Settings()
@@ -24,7 +24,7 @@ router = APIRouter()
 async def export_user(
     user_id: int,
     x_sign: str = Header(..., alias="X-Sign"),
-    auth_user: int = Depends(require_api_headers),
+    auth_user: int = Depends(rate_limit),
 ):
     payload = {"user_id": user_id}
     expected_sign = compute_signature(HMAC_SECRET, payload)
@@ -73,7 +73,7 @@ async def export_user(
 async def delete_user(
     request: Request,
     x_sign: str = Header(..., alias="X-Sign"),
-    auth_user: int = Depends(require_api_headers),
+    auth_user: int = Depends(rate_limit),
 ):
     try:
         payload = await request.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,4 @@ wrapt==1.17.2
 xmltodict==0.14.2
 yarl==1.20.1
 zipp==3.20.2
+redis==5.0.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import pytest
 
+from app import dependencies
+
 # Ensure tests run against SQLite when DATABASE_URL is not defined
 os.environ.setdefault("DATABASE_URL", "sqlite:///./app.db")
 
@@ -22,4 +24,43 @@ def client(apply_migrations):
     """Yields a TestClient with lifespan events."""
     with TestClient(app) as client:
         yield client
+
+
+@pytest.fixture(autouse=True)
+def mock_redis(monkeypatch):
+    class _Pipe:
+        def __init__(self, store):
+            self.store = store
+            self.ops = []
+
+        def incr(self, key):
+            self.ops.append(("incr", key))
+            return self
+
+        def expire(self, key, ttl):
+            self.ops.append(("expire", key, ttl))
+            return self
+
+        async def execute(self):
+            results = []
+            for op in self.ops:
+                if op[0] == "incr":
+                    key = op[1]
+                    self.store[key] = self.store.get(key, 0) + 1
+                    results.append(self.store[key])
+                else:
+                    results.append(True)
+            self.ops.clear()
+            return results
+
+    class _Redis:
+        def __init__(self):
+            self.store = {}
+
+        def pipeline(self):
+            return _Pipe(self.store)
+
+    fake = _Redis()
+    monkeypatch.setattr(dependencies, "redis_client", fake)
+    yield
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,28 @@
+import os
+
+HEADERS = {
+    "X-API-Key": os.getenv("API_KEY", "test-api-key"),
+    "X-API-Ver": "v1",
+    "X-User-ID": "1",
+}
+
+
+def test_rate_limit_ip(client):
+    headers = HEADERS.copy()
+    headers["X-Forwarded-For"] = "1.1.1.1"
+    for _ in range(30):
+        resp = client.get("/v1/photos", headers=headers)
+        assert resp.status_code == 200
+    resp = client.get("/v1/photos", headers=headers)
+    assert resp.status_code == 429
+
+
+def test_rate_limit_user(client):
+    headers = HEADERS.copy()
+    for i in range(120):
+        headers["X-Forwarded-For"] = f"10.0.0.{i//30}"
+        resp = client.get("/v1/photos", headers=headers)
+        assert resp.status_code == 200
+    headers["X-Forwarded-For"] = "10.0.0.4"
+    resp = client.get("/v1/photos", headers=headers)
+    assert resp.status_code == 429


### PR DESCRIPTION
Type: [feature]

## Summary
- connect Redis client and add rate_limit dependency
- throttle /ai/diagnose, /photos, /limits and other user endpoints
- expose `REDIS_URL` config and document in `.env.template`
- cover rate limiting with tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa4290074832abf25f94aeea03071