### PR TITLE
feat: enforce IP allowlists for webhooks

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,12 @@ class Settings(BaseSettings):
     hmac_secret_partner: str = Field(
         "test-hmac-partner", alias="HMAC_SECRET_PARTNER"
     )
+    tinkoff_ips: list[str] = Field(
+        default_factory=lambda: ["127.0.0.1", "testclient"]
+    )
+    partner_ips: list[str] = Field(
+        default_factory=lambda: ["127.0.0.1", "testclient"]
+    )
     tinkoff_terminal_key: str = "tinkoff-terminal-key"
     tinkoff_secret_key: str = "tinkoff-secret-key"
     free_monthly_limit: int = 5

--- a/app/controllers/partners.py
+++ b/app/controllers/partners.py
@@ -1,15 +1,20 @@
 import asyncio
+import logging
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 from app import db as db_module
+from app.config import Settings
 from app.dependencies import (
     ErrorResponse,
     rate_limit,
     verify_partner_hmac,
 )
 from app.models import PartnerOrder
+
+settings = Settings()
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/partner")
 
@@ -32,6 +37,11 @@ async def partner_orders(
     _: None = Depends(rate_limit),
     x_sign: str = Header(..., alias="X-Sign"),
 ):
+    client_ip = request.client.host if request.client else ""
+    if client_ip not in settings.partner_ips:
+        logger.warning("audit: forbidden ip %s", client_ip)
+        raise HTTPException(status_code=403, detail="FORBIDDEN")
+
     data, sign, provided_sign = await verify_partner_hmac(request, x_sign)
     try:
         body = PartnerOrderRequest(**data, signature=provided_sign)

--- a/app/controllers/payments.py
+++ b/app/controllers/payments.py
@@ -156,6 +156,11 @@ async def payments_webhook(
     _: None = Depends(rate_limit),
     x_signature: str | None = Header(None, alias="X-Signature"),
 ):
+    client_ip = request.client.host if request.client else ""
+    if client_ip not in settings.tinkoff_ips:
+        logger.warning("audit: forbidden ip %s", client_ip)
+        raise HTTPException(status_code=403, detail="FORBIDDEN")
+
     raw_body = await request.body()
     secure = os.getenv("SECURE_WEBHOOK")
     if secure and not verify_hmac(x_signature or "", raw_body, HMAC_SECRET):
@@ -228,6 +233,11 @@ async def autopay_webhook(
     _: None = Depends(rate_limit),
     x_signature: str | None = Header(None, alias="X-Signature"),
 ):
+    client_ip = request.client.host if request.client else ""
+    if client_ip not in settings.tinkoff_ips:
+        logger.warning("audit: forbidden ip %s", client_ip)
+        raise HTTPException(status_code=403, detail="FORBIDDEN")
+
     raw_body = await request.body()
     secure = os.getenv("SECURE_WEBHOOK")
     if secure and not verify_hmac(x_signature or "", raw_body, HMAC_SECRET):

--- a/tests/test_webhook_ip.py
+++ b/tests/test_webhook_ip.py
@@ -1,0 +1,90 @@
+import logging
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from app import db as db_module
+from app.config import Settings
+from app.dependencies import compute_signature
+from app.main import app
+from app.models import Payment
+
+
+settings = Settings()
+
+
+def _auth_headers():
+    return {
+        "X-API-Key": settings.api_key,
+        "X-API-Ver": "v1",
+        "X-User-ID": "1",
+    }
+
+
+def test_payments_webhook_forbidden_ip(caplog):
+    bad_ip = "10.0.0.1"
+    with TestClient(app, client=(bad_ip, 5000)) as client, caplog.at_level(
+        logging.WARNING
+    ):
+        resp = client.post(
+            "/v1/payments/sbp/webhook", headers=_auth_headers(), json={}
+        )
+    assert resp.status_code == 403
+    assert f"forbidden ip {bad_ip}" in caplog.text
+
+
+def test_payments_webhook_allowed_ip(apply_migrations):
+    allowed_ip = settings.tinkoff_ips[0]
+    external_id = "ext123"
+    with db_module.SessionLocal() as db:
+        payment = Payment(
+            user_id=1,
+            amount=100,
+            currency="RUB",
+            provider="sbp",
+            external_id=external_id,
+            prolong_months=1,
+            status="pending",
+        )
+        db.add(payment)
+        db.commit()
+
+    payload = {
+        "external_id": external_id,
+        "status": "success",
+        "paid_at": datetime.now(timezone.utc).isoformat(),
+    }
+    payload["signature"] = compute_signature(settings.hmac_secret, payload.copy())
+    with TestClient(app, client=(allowed_ip, 5000)) as client:
+        resp = client.post(
+            "/v1/payments/sbp/webhook", headers=_auth_headers(), json=payload
+        )
+    assert resp.status_code == 200
+
+
+def test_partner_orders_forbidden_ip(caplog):
+    bad_ip = "10.0.0.1"
+    headers = _auth_headers() | {"X-Sign": "bad"}
+    with TestClient(app, client=(bad_ip, 5000)) as client, caplog.at_level(
+        logging.WARNING
+    ):
+        resp = client.post("/v1/partner/orders", headers=headers, json={})
+    assert resp.status_code == 403
+    assert f"forbidden ip {bad_ip}" in caplog.text
+
+
+def test_partner_orders_allowed_ip():
+    allowed_ip = settings.partner_ips[0]
+    payload = {
+        "order_id": "ord1",
+        "user_tg_id": 1,
+        "protocol_id": 1,
+        "price_kopeks": 1000,
+    }
+    sign = compute_signature(settings.hmac_secret_partner, payload.copy())
+    payload["signature"] = sign
+    headers = _auth_headers() | {"X-Sign": sign}
+    with TestClient(app, client=(allowed_ip, 5000)) as client:
+        resp = client.post("/v1/partner/orders", headers=headers, json=payload)
+    assert resp.status_code == 202
+


### PR DESCRIPTION
## Summary
- add Tinkoff and partner IP allowlists to settings
- block payment and partner webhooks from unknown IPs
- test allowed and forbidden webhook IPs

## Testing
- `ruff check app tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa8df3120832aaaee407e9f403870