### PR TITLE
fix: narrow protocol import error handling

### DIFF
--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,3 +1,7 @@
+import logging
+import pytest
+from pathlib import Path
+
 from app.services.protocols import find_protocol, import_csv_to_db
 from app.models import Protocol
 from app.db import SessionLocal
@@ -70,3 +74,97 @@ def test_find_protocol_missing():
     import_csv_to_db()
     proto = find_protocol("apple", "unknown")
     assert proto is None
+
+
+def test_import_csv_update_success(tmp_path, monkeypatch):
+    """Update protocols CSV and import new row."""
+
+    csv_file = tmp_path / "protocols.csv"
+
+    def fake_update_protocols_csv(output: Path) -> Path:
+        output.write_text(
+            "crop,disease,product,dosage_value,dosage_unit,phi\n"
+            "corn,blight,Prod3,1,l_per_ha,10\n",
+            encoding="utf-8",
+        )
+        return output
+
+    monkeypatch.setattr(
+        "scripts.update_protocols.update_protocols_csv", fake_update_protocols_csv
+    )
+
+    with SessionLocal() as session:
+        session.query(Protocol).delete()
+        session.commit()
+
+    import_csv_to_db(path=csv_file, update=True)
+
+    try:
+        with SessionLocal() as session:
+            proto = (
+                session.query(Protocol)
+                .filter(Protocol.crop == "corn", Protocol.disease == "blight")
+                .one()
+            )
+            assert proto.product == "Prod3"
+    finally:
+        with SessionLocal() as session:
+            session.query(Protocol).delete()
+            session.commit()
+        import_csv_to_db()
+
+
+def test_import_csv_update_expected_failure(tmp_path, monkeypatch, caplog):
+    """Use cached CSV when update script raises expected errors."""
+
+    csv_file = tmp_path / "protocols.csv"
+    csv_file.write_text(
+        "crop,disease,product,dosage_value,dosage_unit,phi\n"
+        "barley,smut,Prod4,2,l_per_ha,7\n",
+        encoding="utf-8",
+    )
+
+    def failing_update_protocols_csv(output: Path) -> Path:
+        raise OSError("network down")
+
+    monkeypatch.setattr(
+        "scripts.update_protocols.update_protocols_csv", failing_update_protocols_csv
+    )
+
+    with SessionLocal() as session:
+        session.query(Protocol).delete()
+        session.commit()
+
+    with caplog.at_level(logging.WARNING):
+        import_csv_to_db(path=csv_file, update=True)
+        assert "CSV download failed" in caplog.text
+
+    try:
+        with SessionLocal() as session:
+            proto = (
+                session.query(Protocol)
+                .filter(Protocol.crop == "barley", Protocol.disease == "smut")
+                .one()
+            )
+            assert proto.product == "Prod4"
+    finally:
+        with SessionLocal() as session:
+            session.query(Protocol).delete()
+            session.commit()
+        import_csv_to_db()
+
+
+def test_import_csv_update_unexpected_failure(tmp_path, monkeypatch):
+    """Unexpected errors from update script should surface."""
+
+    csv_file = tmp_path / "protocols.csv"
+
+    def bad_update_protocols_csv(output: Path) -> Path:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(
+        "scripts.update_protocols.update_protocols_csv", bad_update_protocols_csv
+    )
+
+    with pytest.raises(ValueError):
+        import_csv_to_db(path=csv_file, update=True)


### PR DESCRIPTION
## Summary
- log and re-raise unexpected errors when refreshing protocols.csv
- guard debug search path lookup from SQL errors
- cover CSV update success and failure paths in unit tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fb0d6b37c832a98b4556fadc8942c