### PR TITLE
fix: handle optional diagnosis keyboard

### DIFF
--- a/bot/diagnosis.js
+++ b/bot/diagnosis.js
@@ -133,7 +133,8 @@ async function photoHandler(pool, ctx) {
     }
 
     const { text, keyboard } = formatDiagnosis(ctx, data);
-    await ctx.reply(text, { reply_markup: keyboard });
+    const opts = keyboard ? { reply_markup: keyboard } : undefined;
+    await ctx.reply(text, opts);
   } catch (err) {
     console.error('diagnose error', err);
     if (typeof ctx.reply === 'function') {
@@ -173,7 +174,8 @@ async function retryHandler(ctx, photoId) {
     }
 
     const { text, keyboard } = formatDiagnosis(ctx, data);
-    await ctx.reply(text, { reply_markup: keyboard });
+    const opts = keyboard ? { reply_markup: keyboard } : undefined;
+    await ctx.reply(text, opts);
   } catch (err) {
     console.error('retry error', err);
     await ctx.reply(msg('status_error'));

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -239,7 +239,7 @@ test('photoHandler hides expert button when disabled', { concurrency: false }, a
   }, async () => {
     await photoHandler(pool, ctx);
   });
-  assert.equal(replies[0].opts.reply_markup, undefined);
+  assert.equal(replies[0].opts, undefined);
 });
 
 test('photoHandler paywall on 402', { concurrency: false }, async () => {
@@ -457,6 +457,7 @@ test('retryHandler returns result', { concurrency: false }, async () => {
     await retryHandler(ctx, 42);
   });
   assert.ok(replies[0].msg.includes('Культура: apple'));
+  assert.equal(replies[0].opts, undefined);
 });
 
 test('historyHandler paginates', { concurrency: false }, async () => {


### PR DESCRIPTION
## Summary
- handle missing diagnosis keyboard
- test handlers without reply markup

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_688fb2d57a34832aae88e5210107a5dc