### PR TITLE
[fix] preserve product name in protocol callbacks

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -7,6 +7,7 @@ const {
   photoHandler,
   messageHandler,
   retryHandler,
+  getProductName,
 } = require('./diagnosis');
 const {
   subscribeHandler,
@@ -200,6 +201,27 @@ test('formatDiagnosis trims long product names and limits callback_data', () => 
   const cb = keyboard.inline_keyboard[0][0].callback_data;
   assert.ok(cb.length <= 64);
   assert.ok(!cb.includes('AAAAAA'));
+});
+
+test('formatDiagnosis keeps original product name for callback', () => {
+  const ctx = { from: { id: 1 } };
+  const longName = 'B'.repeat(40);
+  const data = {
+    crop: 'c',
+    disease: 'd',
+    confidence: 0.9,
+    protocol: {
+      product: longName,
+      dosage_value: 1,
+      dosage_unit: 'ml',
+      phi: 10,
+    },
+  };
+  const { keyboard } = formatDiagnosis(ctx, data);
+  const cb = keyboard.inline_keyboard[0][0].callback_data;
+  const [, prod] = cb.split('|');
+  const decoded = decodeURIComponent(prod);
+  assert.equal(getProductName(decoded), longName);
 });
 
 test('photoHandler shows expert button when enabled', { concurrency: false }, async () => {

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const { Telegraf } = require('telegraf');
 const { Pool } = require('pg');
-const { photoHandler, messageHandler, retryHandler } = require('./diagnosis');
+const { photoHandler, messageHandler, retryHandler, getProductName } = require('./diagnosis');
 const { subscribeHandler, buyProHandler } = require('./payments');
 const { historyHandler } = require('./history');
 const {
@@ -73,7 +73,9 @@ async function init() {
         await ctx.answerCbQuery();
         return ctx.reply('Некорректный формат данных.');
       }
-      const [, product, val, unit, phi] = parts;
+      const [, productHashEnc, val, unit, phi] = parts;
+      const productHash = decodeURIComponent(productHashEnc);
+      const product = getProductName(productHash) || productHash;
       const msg =
         `Препарат: ${product}\n` +
         `Доза: ${val} ${unit}\n` +


### PR DESCRIPTION
## Summary
- keep original product name and send hashed value in callback
- show original product name when handling protocol callbacks
- cover protocol callback with unit test

## Testing
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901e5a8cfc832a8127a487ea451a5b