### PR TITLE
fix: install Tk dependencies in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 WORKDIR /app
+RUN apt-get update && apt-get install -y ghostscript python3-tk && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . ./


### PR DESCRIPTION
Type: fix

## Summary
- use python 3.11-slim base image
- install ghostscript and python3-tk
- confirm docker-compose builds from repository root

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890202a4dd8832aa90ada64ef631bed