### PR TITLE
fix: enforce Python 3.11 requirement

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -29,6 +30,8 @@ async def lifespan(app: FastAPI):
     yield
     await close_client()
 
+if sys.version_info[:2] < (3, 11):
+    raise RuntimeError("Python 3.11+ is required")
 
 app = FastAPI(
     title="Agronom Bot Internal API",


### PR DESCRIPTION
Type: [fix]

## Summary
- validate Python version at startup

## Testing
- `ruff check app tests`
- `pytest`

Linked issues: N/A

------
https://chatgpt.com/codex/tasks/task_e_68902d202c70832a90f863be1789eab0