### PR TITLE
Add bs4 and pendulum dependencies with smoke tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ ruff==0.12.7
 pre-commit==4.2.0
 camelot-py[cv]~=0.11
 opencv-python<4.8
+beautifulsoup4~=4.12
+pendulum~=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,3 +83,5 @@ wrapt==1.17.2
 xmltodict==0.14.2
 yarl==1.20.1
 zipp==3.20.2
+beautifulsoup4~=4.12
+pendulum~=3.0

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -128,3 +128,13 @@ def test_camelot_import():
         json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.smoke
+def test_bs4_import():
+    import bs4  # noqa: F401
+
+
+@pytest.mark.smoke
+def test_pendulum_import():
+    import pendulum  # noqa: F401


### PR DESCRIPTION
## Summary
- add beautifulsoup4 and pendulum dependencies
- smoke tests for bs4 and pendulum imports

## Testing
- `pip install -r requirements.txt`
- `ruff check app tests`
- `pytest` *(fails: ImportError: numpy.core.multiarray failed to import)*

------
https://chatgpt.com/codex/tasks/task_e_689034567b68832ab219f742cdd80d3d