### PR TITLE
docs: document catalog importer workflow

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -23,6 +23,7 @@
 | --------------- | ----------------------------------------------------------- |
 | Языки / Runtime | **Node.js 20** (TypeScript strict)                          |
 | ML              | **GPT‑Vision API (OpenAI)**                                 |
+| Data Sources    | Government pesticide catalogs                               |
 | Storage         | **PostgreSQL 15**, S3‑совместимое хранилище (VK S3 / Minio) |
 | Cache / Queue   | Redis 7 (Phase B, опционально)                              |
 | Secrets         | **Hashicorp Vault CSI**                                     |

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -1,6 +1,6 @@
 Data Contract – «Карманный агроном» (Bot‑Phase)
 
-Version 1.10 — 5 August 2025(v1.9 → v1.10: ProtocolResponse дополнился category/status/waiting_days)
+Version 1.11 — 5 August 2025(v1.10 → v1.11: добавлены таблицы catalogs/catalog_items и ER‑диаграмма)
 
 0 · Scope
 
@@ -23,6 +23,25 @@ users 1—n payments
 users 1—n partner_orders
 users 1—n events
 photos 1—1 protocols
+catalogs 1—n catalog_items
+
+```mermaid
+erDiagram
+    catalogs ||--o{ catalog_items : contains
+    catalogs {
+        int id
+        text crop
+        text disease
+    }
+    catalog_items {
+        int id
+        int catalog_id
+        text product
+        numeric dosage_value
+        text dosage_unit
+        int phi
+    }
+```
 
 3 · Table Definitions
 
@@ -283,6 +302,58 @@ e.g. payment_success, autopay_fail
 ts
 
 TIMESTAMP DEFAULT now()
+
+3.8 catalogs
+
+Column
+
+Type
+
+Notes
+
+id
+
+SERIAL PK
+
+crop
+
+TEXT
+
+disease
+
+TEXT
+
+3.9 catalog_items
+
+Column
+
+Type
+
+Notes
+
+id
+
+SERIAL PK
+
+catalog_id
+
+INT FK → catalogs(id)
+
+product
+
+TEXT
+
+dosage_value
+
+NUMERIC
+
+dosage_unit
+
+TEXT
+
+phi
+
+INT
 
 4 · Enum Definitions
 

--- a/docs/protocol_import.md
+++ b/docs/protocol_import.md
@@ -1,0 +1,38 @@
+Protocol Import – «Карманный агроном»
+
+Версия 1.0 — 5 августа 2025 г.
+
+1 · Workflow
+
+Утилита `app.services.protocol_importer`:
+1. скачивает HTML-страницу каталога по категории;
+2. находит последнюю ссылку на архив `.zip`;
+3. загружает архив и извлекает PDF;
+4. конвертирует PDF → CSV;
+5. вставляет строки в таблицы `catalogs` и `catalog_items` (без `--force` повторный импорт пропускается).
+
+2 · Manual run
+
+```bash
+python -m app.services.protocol_importer --category main
+```
+
+Флаг `--force` перезаписывает существующие данные. Доступны категории `main`, `pesticide`, `agrochem`.
+
+3 · Cron setup
+
+Ежемесячный запуск в Kubernetes CronJob (`0 9 1 * *`, МСК): см. `k8s/cron_catalog_import.yaml`.
+
+4 · Rollback
+
+1. При ошибках удалите данные:
+   ```sql
+   DELETE FROM catalog_items; DELETE FROM catalogs;
+   ```
+2. Запустите импорт с предыдущим архивом:
+   ```bash
+   python -m app.services.protocol_importer <prev_zip_url> --force
+   ```
+3. Проверьте восстановление (`SELECT COUNT(*) FROM catalog_items`).
+
+Документ `docs/protocol_import.md` (v1.0).


### PR DESCRIPTION
## Summary
- document protocol importer workflow and cron setup
- add ER diagram and table definitions for catalog tables
- reference government catalogs in ADR

## Testing
- `ruff check app tests`
- `pytest`
- `npx spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_6890aae9cdb4832a8d366f961f4d36e6