### PR TITLE
fix: return 400 for malformed JSON in delete_user

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -77,9 +77,11 @@ async def delete_user(
 ):
     try:
         payload = await request.json()
-    except Exception as err:  # noqa: BLE001
+    except json.JSONDecodeError as err:
         err_resp = ErrorResponse(code="BAD_REQUEST", message="Invalid JSON")
         raise HTTPException(status_code=400, detail=err_resp.model_dump()) from err
+    except Exception:  # noqa: BLE001
+        raise
 
     user_id = payload.get("user_id")
     if user_id is None:


### PR DESCRIPTION
## Summary
- validate JSON payload in delete_user

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b03e355c832a9f4c9147a233f374