### PR TITLE
chore: add dockerignore for API build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Files and directories excluded from the API build context
+.git
+.github
+.gitignore
+docker-compose.yml
+node_modules/
+tests/
+docs/
+locales/
+bot/
+monitoring/
+k8s/
+runbooks/
+scripts/


### PR DESCRIPTION
Type: [refactor]

## Summary
- add `.dockerignore` to trim API build context

## Testing
- `ruff check app tests`
- `pytest`
- `docker compose --progress=plain build api` *(fails: docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6890d0bbea68832aa798999f3366c964