### PR TITLE
fix: include bot directory in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,9 @@ node_modules/
 tests/
 docs/
 locales/
-bot/
+# bot/
 monitoring/
 k8s/
 runbooks/
 scripts/
+


### PR DESCRIPTION
## Summary
- ensure the `bot` directory is part of Docker build context by commenting it out in `.dockerignore`

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`
- `docker-compose build bot` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_6890d7458dfc832aaabb036e437b09ff