### PR TITLE
chore: drop compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   api:
     build: .


### PR DESCRIPTION
## Summary
- remove explicit docker-compose version declaration

## Testing
- `alembic upgrade head`
- `ruff check app tests`
- `pytest`
- `npx --no-install spectral lint openapi/openapi.yaml`
- `npx --no-install openapi-diff openapi/openapi.yaml openapi/openapi.yaml` *(fails: missing package)*

------
https://chatgpt.com/codex/tasks/task_e_6890d91ceb08832a87855bc13ac60b8e