### PR TITLE
refactor: adjust bot docker build context

### DIFF
--- a/bot/.dockerignore
+++ b/bot/.dockerignore
@@ -1,0 +1,6 @@
+# Files and directories excluded from the bot build context
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+*.test.js

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18
 WORKDIR /usr/src/app
-COPY bot/package*.json ./bot/
-RUN npm ci --prefix bot
+COPY package*.json ./
+RUN npm ci
 COPY . .
-ENTRYPOINT ["node", "bot/index.js"]
+ENTRYPOINT ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
 
   bot:
     build:
-      context: .
-      dockerfile: bot/Dockerfile
+      context: ./bot
+      dockerfile: Dockerfile
     volumes:
       - .:/usr/src/app
     env_file: .env


### PR DESCRIPTION
## Summary
- build bot image from its own directory with local Dockerfile
- copy bot files directly during image build and add bot-specific dockerignore

## Testing
- `ruff check app tests`
- `pytest`
- `npm ci --prefix bot`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_6890db6ba064832a97a1984a72ac2e01