### PR TITLE
[refactor] order SBP service imports

### DIFF
--- a/app/services/sbp.py
+++ b/app/services/sbp.py
@@ -1,8 +1,7 @@
-import os
 import logging
+import os
 
 import httpx
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure `os` and `logging` are imported before `httpx` in SBP service

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ebd92b98832aa8ee84aa07e8d7d0