### PR TITLE
[feature] add reminder command

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -4,6 +4,7 @@ const { Pool } = require('pg');
 const { photoHandler, messageHandler, retryHandler, getProductName } = require('./diagnosis');
 const { subscribeHandler, buyProHandler } = require('./payments');
 const { historyHandler } = require('./history');
+const { reminderHandler } = require('./reminder');
 const {
   startHandler,
   helpHandler,
@@ -36,6 +37,7 @@ async function init() {
       { command: 'autopay_enable', description: 'Включить автоплатёж' },
       { command: 'cancel_autopay', description: 'Отключить автоплатёж' },
       { command: 'ask_expert', description: 'Задать вопрос эксперту' },
+      { command: 'reminder', description: 'Управление напоминаниями' },
     ]);
 
     bot.start(async (ctx) => {
@@ -62,6 +64,8 @@ async function init() {
     bot.command('ask_expert', async (ctx) => {
       await askExpertHandler(ctx, pool);
     });
+
+    bot.command('reminder', reminderHandler);
 
     bot.on('photo', (ctx) => photoHandler(pool, ctx));
 

--- a/bot/reminder.js
+++ b/bot/reminder.js
@@ -1,0 +1,5 @@
+async function reminderHandler(ctx) {
+  await ctx.reply('Напоминания пока недоступны.');
+}
+
+module.exports = { reminderHandler };


### PR DESCRIPTION
## Summary
- add reminder command to Telegram bot
- add placeholder reminder handler

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ec7e36b8832a9d41528b5691d918