### PR TITLE
style: group standard imports

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -3,6 +3,7 @@ import hmac
 import io
 import json
 import zipfile
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 


### PR DESCRIPTION
## Summary
- group standard library imports in `users.py`
- confirm usage of `asyncio.to_thread`, `hmac.compare_digest`, and `io.BytesIO`

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ee1e10e0832a8aee225ea3286582