### PR TITLE
feat(bot): add feedback command

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -35,9 +35,9 @@ async function feedbackHandler(ctx, pool) {
   if (ctx.from) {
     await logEvent(pool, ctx.from.id, 'feedback_open');
   }
-  await ctx.reply('Будем рады вашему отзыву!', {
+  await ctx.reply(msg('feedback_text'), {
     reply_markup: {
-      inline_keyboard: [[{ text: 'Оставить отзыв', url: url.toString() }]],
+      inline_keyboard: [[{ text: msg('feedback_button'), url: url.toString() }]],
     },
   });
 }

--- a/bot/index.js
+++ b/bot/index.js
@@ -8,6 +8,7 @@ const { reminderHandler } = require('./reminder');
 const {
   startHandler,
   helpHandler,
+  feedbackHandler,
   cancelAutopayHandler,
   autopayEnableHandler,
   askExpertHandler,
@@ -38,6 +39,7 @@ async function init() {
       { command: 'cancel_autopay', description: 'Отключить автоплатёж' },
       { command: 'ask_expert', description: 'Задать вопрос эксперту' },
       { command: 'reminder', description: 'Управление напоминаниями' },
+      { command: 'feedback', description: 'Оставить отзыв' },
     ]);
 
     bot.start(async (ctx) => {
@@ -66,6 +68,8 @@ async function init() {
     });
 
     bot.command('reminder', reminderHandler);
+
+    bot.command('feedback', (ctx) => feedbackHandler(ctx, pool));
 
     bot.on('photo', (ctx) => photoHandler(pool, ctx));
 

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -17,5 +17,7 @@
   "history_error": "Ошибка получения истории",
   "history_empty": "История пуста",
   "autopay_cancel_success": "Автоплатёж отключён",
-  "autopay_cancel_error": "Не удалось отключить автоплатёж"
+  "autopay_cancel_error": "Не удалось отключить автоплатёж",
+  "feedback_text": "Будем рады вашему отзыву!",
+  "feedback_button": "Оставить отзыв"
 }


### PR DESCRIPTION
## Summary
- add /feedback command with inline feedback link
- localize feedback prompt and button

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f4e7b82c832aa8f73f319f9215bd