### PR TITLE
feat: add FAQ start handler

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -6,6 +6,16 @@ async function startHandler(ctx, pool) {
     await logEvent(pool, ctx.from.id, 'paywall_click_buy');
   } else if (ctx.startPayload === 'faq') {
     await logEvent(pool, ctx.from.id, 'paywall_click_faq');
+    return ctx.reply(msg('faq'), {
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: msg('faq_buy_button'), callback_data: 'buy_pro' },
+            { text: msg('faq_back_button'), url: 'https://t.me/YourBot' },
+          ],
+        ],
+      },
+    });
   }
   await ctx.reply(msg('start'));
 }

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -325,6 +325,17 @@ test('startHandler replies with onboarding text', { concurrency: false }, async 
   assert.equal(msg, tr('start'));
 });
 
+test('startHandler replies with FAQ', { concurrency: false }, async () => {
+  const replies = [];
+  const ctx = { startPayload: 'faq', from: { id: 2 }, reply: async (m, opts) => replies.push({ msg: m, opts }) };
+  await startHandler(ctx, { query: async () => {} });
+  assert.equal(replies[0].msg, tr('faq'));
+  const btns = replies[0].opts.reply_markup.inline_keyboard[0];
+  assert.equal(btns[0].callback_data, 'buy_pro');
+  assert.equal(btns[0].text, tr('faq_buy_button'));
+  assert.equal(btns[1].text, tr('faq_back_button'));
+});
+
 test('buyProHandler returns payment link', { concurrency: false }, async () => {
   const replies = [];
   const ctx = { from: { id: 1 }, answerCbQuery: () => {}, reply: async (msg, opts) => replies.push({ msg, opts }) };

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -19,5 +19,8 @@
   "autopay_cancel_success": "Автоплатёж отключён",
   "autopay_cancel_error": "Не удалось отключить автоплатёж",
   "feedback_text": "Будем рады вашему отзыву!",
-  "feedback_button": "Оставить отзыв"
+  "feedback_button": "Оставить отзыв",
+  "faq": "Зачем нужна подписка? PRO снимает лимит фотографий и поддерживает развитие сервиса.",
+  "faq_buy_button": "Купить PRO",
+  "faq_back_button": "Назад"
 }


### PR DESCRIPTION
## Summary
- send FAQ reply from /start when the faq payload is used
- localize FAQ content and button captions
- cover FAQ flow with tests

## Testing
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f6582690832a81cb0d07814f850c