### PR TITLE
fix: enforce diagnose paywall after usage increment

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -966,13 +966,18 @@ def test_usage_count_persists_when_paywall_hit(monkeypatch, client):
 
 def test_sixth_diagnose_call_returns_402(client):
     """Ensure the 6th diagnose request fails with 402 by default."""
-    for i in range(5):
+    limit = Settings().free_monthly_limit
+    for i in range(limit):
         resp = client.post(
             "/v1/ai/diagnose",
             headers=HEADERS,
             json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
         )
         assert resp.status_code == 200, f"call {i}"
+
+    limits = client.get("/v1/limits", headers=HEADERS)
+    assert limits.status_code == 200
+    assert limits.json()["used_this_month"] == limit
 
     sixth = client.post(
         "/v1/ai/diagnose",


### PR DESCRIPTION
Type: [fix]

## Summary
- commit photo usage increments before querying and clarify paywall uses post-increment counter
- cover paywall behaviour with a test: 6th diagnose call returns HTTP 402

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890feb25d0c832aa25d8aee8518294b