### PR TITLE
fix: specify ImportError for camelot importorskip

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -120,7 +120,7 @@ def test_help_command():
 
 @pytest.mark.smoke
 def test_camelot_import():
-    pytest.importorskip("camelot")
+    pytest.importorskip("camelot", exc_type=ImportError, reason="Camelot not installed")
 
     resp = client.post(
         "/v1/ai/diagnose",


### PR DESCRIPTION
## Summary
- fix smoke test to pass exc_type=ImportError to `pytest.importorskip` for camelot

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891012681f8832aa95f38eec96c55ae