### PR TITLE
test: reset pro expiry after event test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1067,3 +1067,8 @@ def test_pro_expired_event_logged(monkeypatch, client):
     with SessionLocal() as session:
         events = session.query(Event).filter_by(user_id=1).all()
         assert any(e.event == "pro_expired" for e in events)
+
+    # cleanup to not affect other tests
+    with SessionLocal() as session:
+        session.execute(text("UPDATE users SET pro_expires_at=NULL WHERE id=1"))
+        session.commit()


### PR DESCRIPTION
## Summary
- clean up test fixture by resetting pro expiration after pro_expired test

## Testing
- `ruff check app tests`
- `pytest -vv tests/test_api.py::test_pro_expired_event_logged tests/test_api.py::test_diagnose_json_with_protocol`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910449bed4832a9ab247a9531359ce