### PR TITLE
fix(tests): replace data with content for raw byte requests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -466,7 +466,7 @@ def test_create_payment_invalid_json(client):
     resp = client.post(
         "/v1/payments/create",
         headers=HEADERS | {"Content-Type": "application/json"},
-        data="{not-valid",
+        content="{not-valid",
     )
     assert resp.status_code == 400
     assert resp.json() == {"detail": "BAD_REQUEST"}


### PR DESCRIPTION
## Summary
- use `content=` when posting raw bytes in tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689109559c9c832aa6f943ae66ce1903