### PR TITLE
fix: validate SBP webhook payload type

### DIFF
--- a/app/controllers/payments.py
+++ b/app/controllers/payments.py
@@ -177,6 +177,9 @@ async def payments_webhook(
     except (json.JSONDecodeError, TypeError) as err:
         logger.exception("failed to parse webhook body as JSON")
         raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
+    if not isinstance(data, dict):
+        logger.warning("audit: non-object webhook payload")
+        raise HTTPException(status_code=400, detail="BAD_REQUEST")
     provided_sign = data.pop("signature", "")
     expected_sign = compute_signature(HMAC_SECRET, data)
     if not hmac.compare_digest(provided_sign, expected_sign):
@@ -257,6 +260,9 @@ async def autopay_webhook(
     except (json.JSONDecodeError, TypeError) as err:
         logger.exception("failed to parse webhook body as JSON")
         raise HTTPException(status_code=400, detail="BAD_REQUEST") from err
+    if not isinstance(data, dict):
+        logger.warning("audit: non-object webhook payload")
+        raise HTTPException(status_code=400, detail="BAD_REQUEST")
     provided_sign = data.pop("signature", "")
     expected_sign = compute_signature(HMAC_SECRET, data)
     if not hmac.compare_digest(provided_sign, expected_sign):

--- a/tests/test_sbp.py
+++ b/tests/test_sbp.py
@@ -219,3 +219,17 @@ def test_autopay_cancel_user_mismatch(client):
     with SessionLocal() as session:
         user = session.get(User, 1)
         assert user and user.autopay_enabled in (1, True)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["/v1/payments/sbp/webhook", "/v1/payments/sbp/autopay/webhook"],
+)
+@pytest.mark.parametrize("payload", ["[]", "123"])
+def test_webhook_rejects_non_object_json(client, endpoint, payload):
+    resp = client.post(
+        endpoint,
+        headers=HEADERS | {"Content-Type": "application/json"},
+        content=payload,
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate SBP and autopay webhook payloads are JSON objects before signature checks
- test that non-object JSON payloads are rejected with HTTP 400

## Testing
- `ruff check app tests`
- `pytest`
- `alembic upgrade head`
- `npx spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_689110609eac832a9fc2e42ca497d9bb