### PR TITLE
fix: rename postgres service to db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./openapi/openapi.yaml:/app/openapi/openapi.yaml
     depends_on:
-      - postgres
+      - db
       - redis
       - minio
     ports:
@@ -33,12 +33,12 @@ services:
       S3_ENDPOINT: ${S3_ENDPOINT}
     depends_on:
       - api
-      - postgres
+      - db
       - redis
       - minio
     networks:
       - agronet
-  postgres:
+  db:
     image: postgres:15
     environment:
       - LANG=en_US.UTF-8


### PR DESCRIPTION
## Summary
- rename postgres service to db so `docker compose up -d db redis minio` works

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`
- `DATABASE_URL=sqlite:///./test.db alembic upgrade head`
- `npx spectral lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689110eee354832aa9c31d41cd03cf36