### PR TITLE
fix: restrict payment plan validation

### DIFF
--- a/app/controllers/payments.py
+++ b/app/controllers/payments.py
@@ -49,7 +49,7 @@ class AutopayCancelRequest(BaseModel):
 
 class PaymentCreateRequest(BaseModel):
     user_id: int
-    plan: str
+    plan: Literal["pro"]
     months: int = Field(default=1, ge=1, le=MAX_MONTHS)
     autopay: bool | None = None
 
@@ -84,9 +84,6 @@ async def create_payment(request: Request, user_id: int = Depends(rate_limit)):
     if body.user_id != user_id:
         err = ErrorResponse(code="UNAUTHORIZED", message="User ID mismatch")
         raise HTTPException(status_code=401, detail=err.model_dump())
-
-    if body.plan.lower() != "pro":
-        raise HTTPException(status_code=400, detail="BAD_REQUEST")
 
     if body.months < 1 or body.months > MAX_MONTHS:
         raise HTTPException(status_code=400, detail="BAD_REQUEST")

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -231,6 +231,7 @@ components:
           type: integer
         plan:
           type: string
+          enum: [pro]
           example: pro
         months:
           type: integer

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -517,6 +517,13 @@ def test_create_payment_user_id_mismatch(client):
     assert resp.status_code == 401
 
 
+@pytest.mark.parametrize("plan", ["basic", "PRO", ""])
+def test_create_payment_invalid_plan(client, plan):
+    payload = {"user_id": 1, "plan": plan, "months": 1}
+    resp = client.post("/v1/payments/create", headers=HEADERS, json=payload)
+    assert resp.status_code == 400
+
+
 @pytest.mark.parametrize("months", [0, 13])
 def test_create_payment_invalid_months(client, months):
     payload = {"user_id": 1, "plan": "pro", "months": months}


### PR DESCRIPTION
## Summary
- rely on Pydantic Literal to restrict payment plan to `pro`
- remove redundant plan check in `create_payment`
- validate plan via new tests and document in OpenAPI spec

## Testing
- `ruff check app tests`
- `npx spectral lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911a46ac44832a80062f23a584adc7