### PR TITLE
[fix] handle missing API version

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -27,12 +27,16 @@ class ErrorResponse(BaseModel):
 
 async def require_api_headers(
     x_api_key: str = Header(..., alias="X-API-Key"),
-    x_api_ver: str = Header(..., alias="X-API-Ver"),
+    x_api_ver: str | None = Header(None, alias="X-API-Ver"),
     x_user_id: int | None = Header(None, alias="X-User-ID"),
 ) -> int:
+    if x_api_ver is None:
+        err = ErrorResponse(code="UPGRADE_REQUIRED", message="Missing API version")
+        raise HTTPException(status_code=426, detail=err.model_dump())
+
     if x_api_ver != "v1":
-        err = ErrorResponse(code="BAD_REQUEST", message="Invalid API version")
-        raise HTTPException(status_code=400, detail=err.model_dump())
+        err = ErrorResponse(code="UPGRADE_REQUIRED", message="Invalid API version")
+        raise HTTPException(status_code=426, detail=err.model_dump())
 
     if x_api_key != settings.api_key:
         err = ErrorResponse(code="UNAUTHORIZED", message="Invalid API key")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,13 +163,24 @@ def test_diagnose_base64_uses_process(monkeypatch, client):
     assert data["confidence"] == 0.7
 
 
-def test_diagnose_missing_header(client):
+def test_diagnose_missing_api_version(client):
     resp = client.post(
         "/v1/ai/diagnose",
-        headers={"X-API-Key": "test-api-key"},
+        headers={"X-API-Key": "test-api-key", "X-User-ID": "1"},
         json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
     )
-    assert resp.status_code in {400, 422}
+    assert resp.status_code == 426
+    assert resp.json()["detail"]["code"] == "UPGRADE_REQUIRED"
+
+
+def test_diagnose_invalid_api_version(client):
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers={"X-API-Key": "test-api-key", "X-API-Ver": "v2", "X-User-ID": "1"},
+        json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
+    )
+    assert resp.status_code == 426
+    assert resp.json()["detail"]["code"] == "UPGRADE_REQUIRED"
 
 
 def test_diagnose_invalid_key(client):


### PR DESCRIPTION
## Summary
- return 426 Upgrade Required when X-API-Ver header is missing or invalid
- cover missing/invalid X-API-Ver in tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891831ac4d0832a9b4ffcb1d697f604