### PR TITLE
[feature] validate JWT and CSRF for autopay cancel

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
     hmac_secret: str = "test-hmac-secret"
+    jwt_secret: str = Field("test-jwt-secret", alias="JWT_SECRET")
     hmac_secret_partner: str = Field(
         "test-hmac-partner", alias="HMAC_SECRET_PARTNER"
     )

--- a/app/middleware/csrf.py
+++ b/app/middleware/csrf.py
@@ -1,0 +1,19 @@
+"""CSRF validation utilities."""
+from __future__ import annotations
+
+import hmac
+from fastapi import Request, HTTPException
+
+from app.dependencies import ErrorResponse
+
+
+async def validate_csrf(request: Request, header_token: str | None) -> None:
+    """Validate double-submit CSRF token via header and cookie."""
+    cookie_token = request.cookies.get("csrf_token")
+    if (
+        header_token is None
+        or cookie_token is None
+        or not hmac.compare_digest(header_token, cookie_token)
+    ):
+        err = ErrorResponse(code="FORBIDDEN", message="Invalid CSRF token")
+        raise HTTPException(status_code=403, detail=err.model_dump())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ camelot-py[cv]~=0.11
 opencv-python<4.8
 beautifulsoup4~=4.12
 pendulum~=3.0
+PyJWT==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,6 +63,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-multipart==0.0.20
 pytz==2025.2
+PyJWT==2.9.0
 PyYAML==6.0.2
 redis==5.0.4
 requests==2.32.4


### PR DESCRIPTION
## Summary
- validate Telegram JWT and double-submit CSRF tokens on autopay cancel
- add CSRF validation utility
- cover success and failure scenarios in SBP tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689187c45644832a8ebaa1b744c8772d