### PR TITLE
feat(worker): notify pro expiration

### DIFF
--- a/worker/pro_expiry_notify.js
+++ b/worker/pro_expiry_notify.js
@@ -1,0 +1,58 @@
+require('dotenv').config();
+const { Queue, Worker } = require('bullmq');
+const { Pool } = require('pg');
+
+async function sendTgMessage(chatId, text) {
+  const token = process.env.BOT_TOKEN_DEV;
+  if (!token) {
+    throw new Error('BOT_TOKEN_DEV not set');
+  }
+  const body = new URLSearchParams({ chat_id: String(chatId), text });
+  await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+}
+
+async function notifyExpiringUsers(pool, sendMessage = sendTgMessage) {
+  const client = await pool.connect();
+  try {
+    const { rows } = await client.query(
+      "SELECT tg_id FROM users WHERE pro_expires_at::date = (now() + interval '3 day')::date"
+    );
+    for (const row of rows) {
+      await sendMessage(row.tg_id, 'Ваша подписка PRO истекает через 3 дня. Продлите её, чтобы сохранить доступ.');
+    }
+    console.log(`Pro expiry notify: notified=${rows.length}`);
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { notifyExpiringUsers };
+
+if (require.main === module) {
+  const connection = { connectionString: process.env.REDIS_URL || 'redis://localhost:6379' };
+  const queueName = 'pro-expiry-notify';
+  const queue = new Queue(queueName, { connection });
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  async function schedule() {
+    const jobs = await queue.getRepeatableJobs();
+    const alreadyScheduled = jobs.some((job) => job.id === 'notify');
+    if (alreadyScheduled) return;
+    await queue.add(
+      'notify',
+      {},
+      {
+        jobId: 'notify',
+        repeat: { cron: process.env.PRO_NOTIFY_CRON || '0 9 * * *', tz: 'Europe/Moscow' },
+        removeOnComplete: true,
+      }
+    );
+  }
+
+  schedule();
+  new Worker(queueName, () => notifyExpiringUsers(pool), { connection });
+}

--- a/worker/pro_expiry_notify.test.js
+++ b/worker/pro_expiry_notify.test.js
@@ -1,0 +1,20 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { notifyExpiringUsers } = require('./pro_expiry_notify');
+
+test('sends notifications to expiring users', async () => {
+  const pool = {
+    connect: async () => ({
+      query: async () => ({ rows: [{ tg_id: 1 }, { tg_id: 2 }] }),
+      release: () => {},
+    }),
+  };
+  const sent = [];
+  async function sendMessage(chatId, text) {
+    sent.push({ chatId, text });
+  }
+  await notifyExpiringUsers(pool, sendMessage);
+  assert.equal(sent.length, 2);
+  assert.equal(sent[0].chatId, 1);
+  assert.match(sent[0].text, /PRO/);
+});


### PR DESCRIPTION
## Summary
- schedule daily worker to notify users when pro expires in 3 days
- add unit test verifying notification dispatch

## Testing
- `node worker/pro_expiry_notify.test.js`
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918fdcc294832abe3557b4fde13321