### PR TITLE
feat: paginate photos with id timestamp cursor

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -62,7 +62,7 @@ async function init() {
       await cancelAutopayHandler(ctx);
     });
 
-    bot.command('history', async (ctx) => historyHandler(ctx, 0, pool));
+    bot.command('history', async (ctx) => historyHandler(ctx, '', pool));
 
     bot.command('ask_expert', async (ctx) => {
       await askExpertHandler(ctx, pool);
@@ -113,10 +113,9 @@ async function init() {
     });
 
     bot.action(/^history\|/, async (ctx) => {
-      const [, off] = ctx.callbackQuery.data.split('|');
-      const offset = Math.max(parseInt(off, 10) || 0, 0);
+      const [, cur] = ctx.callbackQuery.data.split('|');
       await ctx.answerCbQuery();
-      return historyHandler(ctx, offset, pool);
+      return historyHandler(ctx, cur || '', pool);
     });
 
     bot.action(/^info\|/, async (ctx) => {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -178,7 +178,7 @@ components:
         next_cursor:
           type: string
           nullable: true
-          description: Передайте значение в ?cursor=… для следующей страницы
+          description: "Передайте значение в ?cursor=… для следующей страницы (формат `<id>:<unix_ts>`)"
 
     PaymentWebhook:
       type: object
@@ -393,7 +393,7 @@ paths:
           in: query
           schema:
             type: string
-          description: Отдаётся в ответе как `next_cursor`
+            description: "Отдаётся в ответе как `next_cursor` (формат: `<id>:<unix_ts>`)"
       responses:
         '200':
           description: Paginated list


### PR DESCRIPTION
## Summary
- include timestamp and id in `/v1/photos` cursor and next_cursor
- switch bot history commands to new cursor-based pagination
- test cursor pagination for photos API

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_689192471c1c832abc917ebbda94ad8f