### PR TITLE
refactor: run GPT vision in thread

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -110,7 +110,7 @@ async def _process_image(contents: bytes, user_id: int) -> tuple[str, str, str, 
 
     key = await upload_photo(user_id, contents)
     try:
-        result = call_gpt_vision_stub(key)
+        result = await asyncio.to_thread(call_gpt_vision_stub, key)
         crop = result.get("crop", "")
         disease = result.get("disease", "")
         conf = result.get("confidence", 0.0)

--- a/tests/test_process_image_async.py
+++ b/tests/test_process_image_async.py
@@ -1,0 +1,31 @@
+import asyncio
+import time
+
+import pytest
+
+from app.controllers import photos
+
+
+@pytest.mark.asyncio
+async def test_process_image_non_blocking(monkeypatch):
+    async def fake_upload_photo(user_id: int, data: bytes) -> str:
+        return "key"
+
+    async def fake_enforce_paywall(user_id: int):
+        return None
+
+    def fake_call_gpt_vision_stub(key: str) -> dict:
+        time.sleep(0.2)
+        return {"crop": "", "disease": "", "confidence": 0.0}
+
+    monkeypatch.setattr(photos, "upload_photo", fake_upload_photo)
+    monkeypatch.setattr(photos, "_enforce_paywall", fake_enforce_paywall)
+    monkeypatch.setattr(photos, "call_gpt_vision_stub", fake_call_gpt_vision_stub)
+
+    start = time.perf_counter()
+    await asyncio.gather(
+        photos._process_image(b"data", 123),
+        asyncio.sleep(0.1),
+    )
+    duration = time.perf_counter() - start
+    assert duration < 0.25


### PR DESCRIPTION
## Summary
- avoid blocking event loop by moving GPT vision call to a thread
- add test ensuring `_process_image` is asynchronous

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891b88863e0832a864399e513e736d7