### PR TITLE
fix: validate JWT expiration

### DIFF
--- a/app/controllers/payments.py
+++ b/app/controllers/payments.py
@@ -360,7 +360,17 @@ async def cancel_autopay(
         raise HTTPException(status_code=401, detail=err.model_dump())
     token = authorization.split(" ", 1)[1]
     try:
-        payload_jwt = jwt.decode(token, settings.jwt_secret, algorithms=["HS256"])
+        payload_jwt = jwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=["HS256"],
+            options={"verify_exp": True},
+        )
+    except jwt.ExpiredSignatureError as exc:
+        err = ErrorResponse(
+            code=ErrorCode.UNAUTHORIZED, message="Expired JWT"
+        )
+        raise HTTPException(status_code=401, detail=err.model_dump()) from exc
     except Exception as exc:  # noqa: BLE001
         err = ErrorResponse(
             code=ErrorCode.UNAUTHORIZED, message="Invalid JWT"


### PR DESCRIPTION
## Summary
- verify JWT expiration when cancelling autopay
- test expired JWT handling for autopay cancellation

## Testing
- `ruff check app tests`
- `alembic upgrade head`
- `npx spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891ca7ad4b4832abe1d50cb828f897f