### PR TITLE
[fix] log slack webhook failures in metrics report

### DIFF
--- a/scripts/metrics_report.py
+++ b/scripts/metrics_report.py
@@ -87,8 +87,11 @@ def send_slack(text: str) -> None:
     if not SLACK_WEBHOOK_URL:
         logging.warning("SLACK_WEBHOOK_URL not configured")
         return
-    resp = requests.post(SLACK_WEBHOOK_URL, json={"text": text}, timeout=10)
-    resp.raise_for_status()
+    try:
+        resp = requests.post(SLACK_WEBHOOK_URL, json={"text": text}, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException:
+        logging.exception("failed to send Slack notification")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- handle Slack webhook errors in metrics report

## Testing
- `ruff check app tests scripts/metrics_report.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d0c9ad20832a8ba6f89ed751e491