### PR TITLE
fix: close pool on init failure

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -132,6 +132,7 @@ async function init() {
     console.log('Bot started');
   } catch (err) {
     console.error('Bot initialization failed', err);
+    await pool.end();
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- ensure bot's DB pool closes if startup fails

## Testing
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d72f8e08832abf9c1413c687ec07