### PR TITLE
fix(payments): narrow JWT error handling

### DIFF
--- a/app/controllers/payments.py
+++ b/app/controllers/payments.py
@@ -371,7 +371,7 @@ async def cancel_autopay(
             code=ErrorCode.UNAUTHORIZED, message="Expired JWT"
         )
         raise HTTPException(status_code=401, detail=err.model_dump()) from exc
-    except Exception as exc:  # noqa: BLE001
+    except jwt.PyJWTError as exc:
         err = ErrorResponse(
             code=ErrorCode.UNAUTHORIZED, message="Invalid JWT"
         )


### PR DESCRIPTION
## Summary
- catch only JWT errors during autopay cancel verification

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d961f310832aad0b5dbc49797b14