### PR TITLE
fix: handle generic image processing errors

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -125,6 +125,11 @@ async def _process_image(contents: bytes, user_id: int) -> tuple[str, str, str, 
         crop = ""
         disease = ""
         conf = 0.0
+    except Exception:
+        logger.exception("GPT error")
+        crop = ""
+        disease = ""
+        conf = 0.0
 
     roi_start = time.perf_counter()
     roi = calculate_roi(crop, disease) if crop and disease else 0.0

--- a/tests/test_process_image_errors.py
+++ b/tests/test_process_image_errors.py
@@ -1,0 +1,31 @@
+import logging
+
+import pytest
+
+from app.controllers import photos
+
+
+@pytest.mark.asyncio
+async def test_process_image_handles_generic_exception(monkeypatch, caplog):
+    async def fake_upload_photo(user_id: int, data: bytes) -> str:
+        return "key"
+
+    async def fake_enforce_paywall(user_id: int):
+        return None
+
+    def fake_call_gpt_vision_stub(key: str) -> dict:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(photos, "upload_photo", fake_upload_photo)
+    monkeypatch.setattr(photos, "_enforce_paywall", fake_enforce_paywall)
+    monkeypatch.setattr(photos, "call_gpt_vision_stub", fake_call_gpt_vision_stub)
+
+    with caplog.at_level(logging.ERROR):
+        key, crop, disease, conf, roi = await photos._process_image(b"data", 123)
+
+    assert key == "key"
+    assert crop == ""
+    assert disease == ""
+    assert conf == 0.0
+    assert roi == 0.0
+    assert "GPT error" in caplog.text


### PR DESCRIPTION
## Summary
- handle unexpected errors during image processing and return safe defaults
- cover generic image processing errors with a unit test

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891dad72530832a9a3bf7c1557569dc