### PR TITLE
fix: handle failed payment create

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -429,6 +429,21 @@ test('buyProHandler polls fail', { concurrency: false }, async () => {
   assert.equal(replies[1].msg, tr('payment_fail'));
 });
 
+test('buyProHandler handles non-ok API status', { concurrency: false }, async () => {
+  const replies = [];
+  const ctx = { from: { id: 6 }, answerCbQuery: () => {}, reply: async (msg, opts) => replies.push({ msg, opts }) };
+  const pool = { query: async () => {} };
+  await withMockFetch(
+    {
+      'http://localhost:8000/v1/payments/create': { ok: false, status: 500 },
+    },
+    async () => {
+      await buyProHandler(ctx, pool, 0);
+    },
+  );
+  assert.equal(replies[0].msg, msg('payment_error'));
+});
+
 test('buyProHandler sends autopay flag', { concurrency: false }, async () => {
   const replies = [];
   const ctx = {

--- a/bot/payments.js
+++ b/bot/payments.js
@@ -63,6 +63,10 @@ async function buyProHandler(
       },
       body: JSON.stringify({ user_id: ctx.from.id, plan: 'pro', months: 1, autopay }),
     });
+    if (!resp.ok) {
+      console.error('payment create error', resp.status);
+      return await ctx.reply(msg('payment_error'));
+    }
     const data = await resp.json();
     ctx.paymentId = data.payment_id;
     const reply = await ctx.reply(msg('payment_prompt'), {


### PR DESCRIPTION
## Summary
- return payment_error message when payment creation API returns non-ok status
- test buyProHandler error response handling

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_68920286ab4c832a94a1902f388c058d