### PR TITLE
fix: guard invalid free photo limit

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -14,6 +14,7 @@ const {
   buyProHandler,
   pollPaymentStatus,
   cancelAutopay,
+  getLimit,
 } = require('./payments');
 const { startHandler, helpHandler, feedbackHandler } = require('./commands');
 const { historyHandler } = require('./history');
@@ -363,6 +364,13 @@ test('startHandler replies with FAQ', { concurrency: false }, async () => {
   assert.equal(btns[0].callback_data, 'buy_pro');
   assert.equal(btns[0].text, tr('faq_buy_button'));
   assert.equal(btns[1].text, tr('faq_back_button'));
+});
+
+test('getLimit falls back to default for invalid env', () => {
+  const orig = process.env.FREE_PHOTO_LIMIT;
+  process.env.FREE_PHOTO_LIMIT = 'abc';
+  assert.equal(getLimit(), 5);
+  process.env.FREE_PHOTO_LIMIT = orig;
 });
 
 test('buyProHandler returns payment link', { concurrency: false }, async () => {

--- a/bot/payments.js
+++ b/bot/payments.js
@@ -9,7 +9,8 @@ function paywallEnabled() {
 }
 
 function getLimit() {
-  return parseInt(process.env.FREE_PHOTO_LIMIT || '5', 10);
+  const limit = parseInt(process.env.FREE_PHOTO_LIMIT, 10);
+  return Number.isNaN(limit) ? 5 : limit;
 }
 
 async function logEvent(pool, userId, ev) {


### PR DESCRIPTION
## Summary
- handle NaN in FREE_PHOTO_LIMIT by falling back to 5
- cover FREE_PHOTO_LIMIT fallback logic with a unit test

## Testing
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689204b76cc0832abfd075d73e3243fc