### PR TITLE
fix: validate column count before CSV conversion

### DIFF
--- a/app/services/protocol_importer.py
+++ b/app/services/protocol_importer.py
@@ -114,6 +114,11 @@ def pdf_to_csv(pdf_path: Path, csv_path: Path) -> Path:
         csv_path.write_text("")
         return csv_path
     df = pd.concat([t.df for t in tables])
+    if df.shape[1] != len(FIELDNAMES):
+        raise ValueError(
+            "Unexpected number of columns in PDF table: "
+            f"{df.shape[1]} (expected {len(FIELDNAMES)})"
+        )
     df.columns = FIELDNAMES
     df.to_csv(csv_path, index=False)
     return csv_path


### PR DESCRIPTION
## Summary
- ensure `pdf_to_csv` validates column count before applying headers
- test column mismatch handling during PDF import

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689206b073c8832abb6050c649713bed