### PR TITLE
fix: align aioboto3 and pytest versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 fastapi==0.116.1
-pytest==8.4.1
+pytest==8.3.5
 ruff==0.12.7
 pre-commit==4.2.0
 camelot-py[cv]~=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aioboto3==15.0.0
-aiobotocore==2.23.0
+aioboto3==14.3.0
+aiobotocore==2.22.0
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.11.18
@@ -9,8 +9,8 @@ alembic==1.14.1
 annotated-types==0.7.0
 anyio==4.5.2
 attrs==25.3.0
-boto3==1.38.27
-botocore==1.38.27
+boto3==1.37.3
+botocore==1.37.3
 cachetools==5.3.3
 camelot-py==0.11.0
 certifi==2025.7.14
@@ -57,7 +57,7 @@ pydantic-settings==2.2.1
 pydantic_core==2.27.2
 pypdf==5.9.0
 Pygments==2.19.2
-pytest==8.4.1
+pytest==8.3.5
 pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
@@ -69,7 +69,7 @@ redis==5.0.4
 requests==2.32.4
 responses==0.25.7
 ruff==0.12.4
-s3transfer==0.13.1
+s3transfer==0.11.3
 six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.41


### PR DESCRIPTION
## Summary
- pin aioboto3 to 14.3.0 and align related AWS libs
- downgrade pytest to 8.3.5 for compatibility

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920b996138832a973c245a27190187