### PR TITLE
chore: adjust aioboto3 and pytest versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 fastapi==0.116.1
-pytest==8.3.5
+pytest>=8.3.5,<8.4.0
 ruff==0.12.7
 pre-commit==4.2.0
 camelot-py[cv]~=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aioboto3==14.3.0
+aioboto3>=14.3.0,<15.0.0
 aiobotocore==2.22.0
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1
@@ -57,7 +57,7 @@ pydantic-settings==2.2.1
 pydantic_core==2.27.2
 pypdf==5.9.0
 Pygments==2.19.2
-pytest==8.3.5
+pytest>=8.3.5,<8.4.0
 pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- relax aioboto3 pin to allow any 14.x release and block 15.x
- constrain pytest to <8.4.0 across runtime and dev requirements

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920dd99444832aaca4414ff1f38f0e