### PR TITLE
fix: pin pytest to 8.3.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 fastapi==0.116.1
-pytest>=8.3.5,<8.4.0
+pytest==8.3.5
 ruff==0.12.7
 pre-commit==4.2.0
 camelot-py[cv]~=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ pydantic-settings==2.2.1
 pydantic_core==2.27.2
 pypdf==5.9.0
 Pygments==2.19.2
-pytest>=8.3.5,<8.4.0
+pytest==8.3.5
 pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- pin pytest to 8.3.5 in requirements files

## Testing
- `pip install -r requirements-dev.txt`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689213055e0c832abdc328e14f5fa44f