### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Exclude directories not needed for building the API image
+.git
+node_modules
+tests
+docs
+locales
+bot
+openapi
+scripts
+runbooks
+k8s
+monitoring
+load


### PR DESCRIPTION
## Summary
- add .dockerignore to trim API build context

## Testing
- `ruff check app tests`
- `pytest`
- `docker-compose build api` *(fails: Error while fetching server API version: connection aborted, no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890cedf2a8c832abfbfba3178e0d379