### PR TITLE
feature: integrate OpenAI vision

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -24,7 +24,7 @@ from app.metrics import (
     roi_calc_seconds,
 )
 from app.models import Event, Photo, ErrorCode
-from app.services.gpt import call_gpt_vision_stub
+from app.services.gpt import call_gpt_vision
 from app.services.protocols import find_protocol
 from app.services.storage import get_public_url, upload_photo
 from app.services.roi import calculate_roi
@@ -110,7 +110,7 @@ async def _process_image(contents: bytes, user_id: int) -> tuple[str, str, str, 
 
     key = await upload_photo(user_id, contents)
     try:
-        result = await asyncio.to_thread(call_gpt_vision_stub, key)
+        result = await asyncio.to_thread(call_gpt_vision, key)
         crop = result.get("crop", "")
         disease = result.get("disease", "")
         conf = result.get("confidence", 0.0)

--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -1,27 +1,82 @@
-"""GPT-Vision integration stubs."""
+"""GPT-Vision integration using the OpenAI client."""
 
 from __future__ import annotations
 
+import json
+import os
+from typing import Dict
 
-def call_gpt_vision_stub(image_path: str) -> dict:
-    """Return mock diagnosis for the given image.
+import httpx
+from openai import OpenAI, OpenAIError
+
+from .storage import get_public_url
+
+
+def _build_client() -> OpenAI:
+    """Configure OpenAI client honouring proxy environment variables."""
+
+    proxies: Dict[str, str] = {}
+    http_proxy = os.environ.get("HTTP_PROXY")
+    https_proxy = os.environ.get("HTTPS_PROXY")
+    if http_proxy:
+        proxies["http://"] = http_proxy
+    if https_proxy:
+        proxies["https://"] = https_proxy
+
+    http_client = httpx.Client(proxies=proxies) if proxies else None
+    api_key = os.environ.get("OPENAI_API_KEY", "test")
+    return OpenAI(api_key=api_key, http_client=http_client)
+
+
+# Reused in tests where it may be monkeypatched
+client = _build_client()
+
+_PROMPT = (
+    "You are an agronomist assistant. "
+    "Identify the crop and disease shown in the image. "
+    "Respond in JSON with fields crop, disease and confidence (0..1)."
+)
+
+
+def call_gpt_vision(key: str) -> dict:
+    """Send photo to GPT‑Vision and parse the diagnosis.
 
     Parameters
     ----------
-    image_path: str
-        Path to the uploaded image. Only used for debugging
-        in this stub implementation.
-
-    Returns
-    -------
-    dict
-        Mocked GPT response with keys:
-        ``crop``, ``disease`` and ``confidence``.
+    key: str
+        S3 object key returned by :func:`app.services.storage.upload_photo`.
     """
-    # In real integration this function would upload the image to GPT-Vision
-    # and parse the JSON response. The stub always returns a fixed payload.
-    return {
-        "crop": "apple",
-        "disease": "powdery_mildew",
-        "confidence": 0.92,
-    }
+
+    image_url = get_public_url(key)
+
+    try:
+        response = client.responses.create(
+            model="gpt-4.1-mini",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _PROMPT},
+                        {"type": "image_url", "image_url": image_url},
+                    ],
+                }
+            ],
+            response_format={"type": "json_object"},
+        )
+    except OpenAIError as exc:  # pragma: no cover - network/SDK errors
+        raise RuntimeError("OpenAI request failed") from exc
+
+    try:
+        payload = response.output[0].content[0].text
+        data = json.loads(payload)
+        crop = data["crop"]
+        disease = data["disease"]
+        confidence = float(data["confidence"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("Malformed GPT response") from exc
+
+    return {"crop": crop, "disease": disease, "confidence": confidence}
+
+
+__all__ = ["call_gpt_vision"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ MarkupSafe==2.1.5
 moto==5.0.12
 multidict==6.6.3
 numpy==2.3.2
+openai==1.63.0
 opencv-python==4.7.0.72
 openpyxl==3.1.5
 packaging==25.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,6 +63,12 @@ def stub_upload(monkeypatch):
 
     monkeypatch.setattr("app.services.storage.upload_photo", _stub)
     monkeypatch.setattr("app.controllers.photos.upload_photo", _stub)
+    
+    def _gpt_stub(_key: str) -> dict:
+        return {"crop": "apple", "disease": "powdery_mildew", "confidence": 0.92}
+
+    monkeypatch.setattr("app.services.gpt.call_gpt_vision", _gpt_stub)
+    monkeypatch.setattr("app.controllers.photos.call_gpt_vision", _gpt_stub)
     # reset usage to avoid 402 errors between tests
     from app.db import SessionLocal
     from app.models import PhotoUsage
@@ -346,7 +352,7 @@ def test_diagnose_gpt_timeout(monkeypatch, client):
     def _fail(_key: str):
         raise TimeoutError("timeout")
 
-    monkeypatch.setattr("app.controllers.photos.call_gpt_vision_stub", _fail)
+    monkeypatch.setattr("app.controllers.photos.call_gpt_vision", _fail)
 
     resp = client.post(
         "/v1/ai/diagnose",

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -1,11 +1,31 @@
-from app.services.gpt import call_gpt_vision_stub
+from types import SimpleNamespace
+
+from app.services import gpt
 
 
-def test_gpt_stub_returns_mock():
-    resp = call_gpt_vision_stub("photo.jpg")
-    assert isinstance(resp, dict)
+def _fake_openai_response() -> SimpleNamespace:
+    payload = (
+        '{"crop":"apple","disease":"powdery_mildew","confidence":0.92}'
+    )
+    return SimpleNamespace(
+        output=[SimpleNamespace(content=[SimpleNamespace(text=payload)])]
+    )
+
+
+def test_call_gpt_vision_parses_response(tmp_path, monkeypatch):
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(b"data")
+
+    class _FakeResponses:
+        def create(self, **kwargs):  # type: ignore[override]
+            return _fake_openai_response()
+
+    monkeypatch.setattr(gpt, "client", SimpleNamespace(responses=_FakeResponses()))
+
+    resp = gpt.call_gpt_vision(str(img))
     assert resp == {
         "crop": "apple",
         "disease": "powdery_mildew",
         "confidence": 0.92,
     }
+

--- a/tests/test_process_image_async.py
+++ b/tests/test_process_image_async.py
@@ -14,13 +14,13 @@ async def test_process_image_non_blocking(monkeypatch):
     async def fake_enforce_paywall(user_id: int):
         return None
 
-    def fake_call_gpt_vision_stub(key: str) -> dict:
+    def fake_call_gpt_vision(key: str) -> dict:
         time.sleep(0.2)
         return {"crop": "", "disease": "", "confidence": 0.0}
 
     monkeypatch.setattr(photos, "upload_photo", fake_upload_photo)
     monkeypatch.setattr(photos, "_enforce_paywall", fake_enforce_paywall)
-    monkeypatch.setattr(photos, "call_gpt_vision_stub", fake_call_gpt_vision_stub)
+    monkeypatch.setattr(photos, "call_gpt_vision", fake_call_gpt_vision)
 
     start = time.perf_counter()
     await asyncio.gather(

--- a/tests/test_process_image_errors.py
+++ b/tests/test_process_image_errors.py
@@ -13,12 +13,12 @@ async def test_process_image_handles_generic_exception(monkeypatch, caplog):
     async def fake_enforce_paywall(user_id: int):
         return None
 
-    def fake_call_gpt_vision_stub(key: str) -> dict:
+    def fake_call_gpt_vision(key: str) -> dict:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(photos, "upload_photo", fake_upload_photo)
     monkeypatch.setattr(photos, "_enforce_paywall", fake_enforce_paywall)
-    monkeypatch.setattr(photos, "call_gpt_vision_stub", fake_call_gpt_vision_stub)
+    monkeypatch.setattr(photos, "call_gpt_vision", fake_call_gpt_vision)
 
     with caplog.at_level(logging.ERROR):
         key, crop, disease, conf, roi = await photos._process_image(b"data", 123)


### PR DESCRIPTION
## Summary
- replace GPT stub with real OpenAI client using optional HTTP/HTTPS proxies
- call vision service from photo controller and parse crop/disease/confidence
- add OpenAI dependency and tests mocking vision responses

## Testing
- `ruff check app tests`
- `pytest`
- `alembic upgrade head`
- `npx spectral lint openapi/openapi.yaml`
- `npx -y openapi-diff openapi/openapi.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689253086c10832a9311400643851e6a