### PR TITLE
fix: remove stray comma in ru locale JSON

### DIFF
--- a/locales/ru.json
+++ b/locales/ru.json
@@ -32,8 +32,7 @@
   "reminder_cancel_button": "Отменить",
   "reminder_cancelled": "Напоминание отменено",
   "reminder_due": "Сработало напоминание",
-  "reminder_error": "Ошибка напоминаний"
-  ,
+  "reminder_error": "Ошибка напоминаний",
   "error_NO_LEAF": "Лист не обнаружен",
   "error_LIMIT_EXCEEDED": "Превышен лимит",
   "error_GPT_TIMEOUT": "GPT не ответил",


### PR DESCRIPTION
## Summary
- fix syntax in ru.json by deleting extraneous comma after `reminder_error`

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_68926225aff4832abbf948d5238a01d3