### PR TITLE
fix: handle diagnosis API error codes

### DIFF
--- a/bot/diagnosis.js
+++ b/bot/diagnosis.js
@@ -120,8 +120,19 @@ async function photoHandler(pool, ctx) {
     }
     if (!apiResp.ok) {
       console.error('API error status', apiResp.status);
+      let errCode;
+      try {
+        const errData = await apiResp.json();
+        errCode = errData?.error_code;
+      } catch (err) {
+        console.error('Failed to parse API error response', err);
+      }
       if (typeof ctx.reply === 'function') {
-        await ctx.reply(msg('diagnose_error'));
+        if (errCode) {
+          await ctx.reply(msg('error_' + errCode));
+        } else {
+          await ctx.reply(msg('diagnose_error'));
+        }
       }
       return;
     }

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -102,6 +102,24 @@ test('photoHandler handles non-ok API status', { concurrency: false }, async () 
   assert.equal(replies[0], msg('diagnose_error'));
 });
 
+test('photoHandler responds with error_code message', { concurrency: false }, async () => {
+  const pool = { query: async () => {} };
+  const replies = [];
+  const ctx = {
+    message: { photo: [{ file_id: 'id1', file_unique_id: 'u', width: 1, height: 1, file_size: 1 }] },
+    from: { id: 1 },
+    reply: async (msg) => replies.push(msg),
+    telegram: { getFileLink: async () => ({ href: 'http://file' }) },
+  };
+  await withMockFetch({
+    'http://file': { arrayBuffer: async () => Buffer.from('x') },
+    default: { ok: false, status: 400, json: async () => ({ error_code: 'NO_LEAF' }) },
+  }, async () => {
+    await photoHandler(pool, ctx);
+  });
+  assert.equal(replies[0], msg('error_NO_LEAF'));
+});
+
 test('photoHandler handles invalid JSON response', { concurrency: false }, async () => {
   const pool = { query: async () => {} };
   const replies = [];


### PR DESCRIPTION
## Summary
- respond with specific error messages when diagnosis API returns error_code
- test error_code handling in photo handler

## Testing
- `ruff check app tests`
- `pytest`
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_689263f9bc08832ab7d218a156fb8343