### PR TITLE
fix: clamp history offset to zero

### DIFF
--- a/fastify/index.js
+++ b/fastify/index.js
@@ -71,7 +71,8 @@ app.post('/v1/ai/diagnose', async function (request, reply) {
 
 app.get('/v1/photos/history', async function (request) {
   const limitParam = parseInt(request.query.limit ?? '10', 10);
-  const offset = parseInt(request.query.offset ?? '0', 10);
+  const parsedOffset = parseInt(request.query.offset ?? '0', 10);
+  const offset = Math.max(0, parsedOffset);
   const limit = Math.min(Number.isNaN(limitParam) ? 10 : limitParam, 50);
 
   let userId = 1;

--- a/tests/fastify_history.test.js
+++ b/tests/fastify_history.test.js
@@ -23,3 +23,14 @@ test('history caps limit at 50', async () => {
   assert.equal(res.statusCode, 200);
   assert.equal(received[1], 50);
 });
+
+test('history treats negative offset as 0', async () => {
+  let received;
+  pool.query = async (sql, params) => {
+    received = params;
+    return { rows: [] };
+  };
+  const res = await app.inject('/v1/photos/history?offset=-5');
+  assert.equal(res.statusCode, 200);
+  assert.equal(received[2], 0);
+});


### PR DESCRIPTION
## Summary
- clamp negative photo history offsets to zero
- cover negative offsets in photo history tests

## Testing
- `node --test tests/fastify_history.test.js`
- `npm test`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926d9c0950832ab199498d6428e60f