### PR TITLE
fix: send image url object to gpt

### DIFF
--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -57,7 +57,10 @@ def call_gpt_vision(key: str) -> dict:
                     "role": "user",
                     "content": [
                         {"type": "text", "text": _PROMPT},
-                        {"type": "image_url", "image_url": image_url},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_url},
+                        },
                     ],
                 }
             ],

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -29,3 +29,24 @@ def test_call_gpt_vision_parses_response(tmp_path, monkeypatch):
         "confidence": 0.92,
     }
 
+
+def test_call_gpt_vision_sends_image_url_object(monkeypatch):
+    captured: dict = {}
+
+    class _FakeResponses:
+        def create(self, **kwargs):  # type: ignore[override]
+            captured["input"] = kwargs["input"]
+            return _fake_openai_response()
+
+    monkeypatch.setattr(
+        gpt,
+        "client",
+        SimpleNamespace(responses=_FakeResponses()),
+    )
+    monkeypatch.setattr(gpt, "get_public_url", lambda key: "https://example.com/x.jpg")
+
+    gpt.call_gpt_vision("some-key")
+
+    image_part = captured["input"][0]["content"][1]
+    assert image_part["image_url"] == {"url": "https://example.com/x.jpg"}
+


### PR DESCRIPTION
## Summary
- wrap image url in object when calling gpt-vision
- add regression test for gpt request

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892ca36ea10832a9a0e72c93db80b5f