### PR TITLE
fix: enforce OpenAI API key presence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Telegram Bot Token (dev)
 
 OPENAI_API_KEY
 
-GPT‑Vision (sandbox)
+GPT‑Vision (sandbox, required)
 
 TINKOFF_TERMINAL_KEY / TINKOFF_SECRET_KEY
 

--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -24,7 +24,9 @@ def _build_client() -> OpenAI:
         proxies["https://"] = https_proxy
 
     http_client = httpx.Client(proxies=proxies) if proxies else None
-    api_key = os.environ.get("OPENAI_API_KEY", "test")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
     return OpenAI(api_key=api_key, http_client=http_client)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from app import dependencies
 
 # Ensure tests run against SQLite when DATABASE_URL is not defined
 os.environ.setdefault("DATABASE_URL", "sqlite:///./app.db")
+os.environ.setdefault("OPENAI_API_KEY", "test")
 
 from fastapi.testclient import TestClient
 from app.main import app

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from app.services import gpt
 
 
@@ -49,4 +51,10 @@ def test_call_gpt_vision_sends_image_url_object(monkeypatch):
 
     image_part = captured["input"][0]["content"][1]
     assert image_part["image_url"] == {"url": "https://example.com/x.jpg"}
+
+
+def test_build_client_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        gpt._build_client()
 


### PR DESCRIPTION
## Summary
- require OPENAI_API_KEY for OpenAI client and raise clear error when missing
- document OPENAI_API_KEY as mandatory
- test missing API key scenario and set default key in tests

## Testing
- `ruff check app tests`
- `npx spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `alembic current`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892cbfc6184832ab1c9d1113b1469f0