### PR TITLE
fix: return error on GPT failures

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -359,17 +359,10 @@ def test_diagnose_gpt_timeout(monkeypatch, client):
         headers=HEADERS,
         json={"image_base64": "dGVzdA==", "prompt_id": "v1"},
     )
-    assert resp.status_code in {200, 202}
+    assert resp.status_code == 502
     data = resp.json()
-    assert data["status"] == "pending"
-    assert "id" in data
-
-    from app.db import SessionLocal
-    from app.models import Photo
-
-    with SessionLocal() as session:
-        photo = session.query(Photo).order_by(Photo.id.desc()).first()
-        assert photo.status == "pending"
+    assert data["code"] == ErrorCode.GPT_TIMEOUT
+    assert data["message"]
 
 
 def test_quota_exceeded(client):


### PR DESCRIPTION
## Summary
- raise specific error responses in `_process_image` on GPT timeouts or bad responses
- test timeout and invalid GPT response scenarios
- adjust diagnose endpoint tests for new GPT timeout behaviour

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892cfb5408c832a8dd7d0684fe03b80