### PR TITLE
fix(migrations): use boolean defaults

### DIFF
--- a/migrations/versions/59e3b0f60693_add_autopay_enabled.py
+++ b/migrations/versions/59e3b0f60693_add_autopay_enabled.py
@@ -25,14 +25,14 @@ def upgrade() -> None:
     if "autopay_enabled" not in user_cols:
         op.add_column(
             "users",
-            sa.Column("autopay_enabled", sa.Boolean(), server_default=sa.text("0")),
+            sa.Column("autopay_enabled", sa.Boolean(), server_default=sa.false()),
         )
 
     payment_cols = {c["name"] for c in inspector.get_columns("payments")}
     with op.batch_alter_table("payments") as batch_op:
         if "autopay" not in payment_cols:
             batch_op.add_column(
-                sa.Column("autopay", sa.Boolean(), server_default=sa.text("0"))
+                sa.Column("autopay", sa.Boolean(), server_default=sa.false())
             )
         if "autopay_charge_id" not in payment_cols:
             batch_op.add_column(sa.Column("autopay_charge_id", sa.String()))

--- a/migrations/versions/cc9e7b060768_add_autopay_fields.py
+++ b/migrations/versions/cc9e7b060768_add_autopay_fields.py
@@ -22,7 +22,9 @@ def upgrade() -> None:
     cols = {c["name"] for c in inspector.get_columns("payments")}
     with op.batch_alter_table("payments") as batch_op:
         if "autopay" not in cols:
-            batch_op.add_column(sa.Column("autopay", sa.Boolean(), server_default=sa.text("0")))
+            batch_op.add_column(
+                sa.Column("autopay", sa.Boolean(), server_default=sa.false())
+            )
         if "autopay_binding_id" not in cols:
             batch_op.add_column(sa.Column("autopay_binding_id", sa.String()))
 


### PR DESCRIPTION
Type: [fix]

## Summary
- use `sa.false()` for `autopay` column default in early autopay migrations
- use `sa.false()` for `autopay_enabled` default and align `autopay` default

## Testing
- `DATABASE_URL=sqlite:///test.db ./scripts/migrate_safe.sh`
- `ruff check migrations app tests`
- `npx --yes spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892d8d6976c832a89b0627b40a2735a