### PR TITLE
fix: use boolean default for catalog items

### DIFF
--- a/migrations/versions/9c0f0b84676a_add_catalog_tables.py
+++ b/migrations/versions/9c0f0b84676a_add_catalog_tables.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
         sa.Column("dosage_value", sa.Numeric(), nullable=False),
         sa.Column("dosage_unit", sa.String(), nullable=False),
         sa.Column("phi", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("is_current", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("is_current", sa.Boolean(), nullable=False, server_default=sa.true()),
     )
     op.execute(
         """
@@ -39,7 +39,7 @@ def upgrade() -> None:
                ci.phi AS phi
         FROM catalog_items ci
         JOIN catalogs c ON c.id = ci.catalog_id
-        WHERE ci.is_current = 1
+        WHERE ci.is_current
         """
     )
     op.drop_table("protocols")


### PR DESCRIPTION
Type: [fix]

## Summary
- ensure `catalog_items.is_current` uses a boolean server default
- update `protocols_current` view to filter by boolean truthiness

## Testing
- `ruff check app tests`
- `pytest`
- `npx --yes spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `python - <<'PY'
from alembic.config import Config
from alembic import command
cfg = Config('alembic.ini')
command.upgrade(cfg, 'head')
print('alembic upgrade head completed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892e0da6e6c832a8a5bc322899c1328