### PR TITLE
fix: use boolean default for opt_in

### DIFF
--- a/migrations/versions/5ef33145d14c_add_opt_in_to_users.py
+++ b/migrations/versions/5ef33145d14c_add_opt_in_to_users.py
@@ -20,7 +20,7 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "users",
-        sa.Column("opt_in", sa.Boolean(), server_default=sa.text("0"), nullable=False),
+        sa.Column("opt_in", sa.Boolean(), server_default=sa.false(), nullable=False),
     )
 
 


### PR DESCRIPTION
## Summary
- use `sa.false()` as the server default for the `opt_in` column in the users migration

## Testing
- `ruff check app tests`
- `pytest`
- `npx spectral lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_6892e40b14e8832aa0f3054e74a803f6