### PR TITLE
fix: init db before running protocol importer

### DIFF
--- a/app/services/protocol_importer.py
+++ b/app/services/protocol_importer.py
@@ -29,6 +29,12 @@ from app import db
 from app.models.catalog import Catalog
 from app.models.catalog_item import CatalogItem
 
+from app.config import Settings
+from app.db import init_db
+
+cfg = Settings()
+init_db(cfg)
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- initialize DB settings in protocol importer module before using sessions

## Testing
- `ruff check app tests`
- `pytest`
- `python -m app.services.protocol_importer --category main`


------
https://chatgpt.com/codex/tasks/task_e_6892eff40028832a9cec8219f00aacb9