### PR TITLE
refactor: detailed HTTP errors

### DIFF
--- a/app/controllers/experts.py
+++ b/app/controllers/experts.py
@@ -27,13 +27,19 @@ async def ask_expert(
 
     try:
         payload = await request.json()
-    except json.JSONDecodeError as err:
-        raise HTTPException(status_code=400, detail=ErrorCode.BAD_REQUEST) from err
+    except json.JSONDecodeError as exc:
+        err = ErrorResponse(
+            code=ErrorCode.BAD_REQUEST, message="Invalid JSON payload"
+        )
+        raise HTTPException(status_code=400, detail=err.model_dump()) from exc
 
     try:
         AskExpertRequest.model_validate(payload)
-    except ValidationError as err:
-        raise HTTPException(status_code=400, detail=ErrorCode.BAD_REQUEST) from err
+    except ValidationError as exc:
+        err = ErrorResponse(
+            code=ErrorCode.BAD_REQUEST, message="Invalid request body"
+        )
+        raise HTTPException(status_code=400, detail=err.model_dump()) from exc
 
     def _db_call() -> None:
         with db_module.SessionLocal() as db:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -587,7 +587,12 @@ def test_create_payment_invalid_json(client):
         content="{not-valid",
     )
     assert resp.status_code == 400
-    assert resp.json() == {"detail": ErrorCode.BAD_REQUEST}
+    assert resp.json() == {
+        "detail": {
+            "code": ErrorCode.BAD_REQUEST,
+            "message": "Invalid JSON payload",
+        }
+    }
 
 
 def test_create_payment_user_id_mismatch(client):


### PR DESCRIPTION
## Summary
- replace bare ErrorCode in HTTPException details with structured ErrorResponse in experts, partners and payments controllers
- include informative messages for common client errors

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689328cfb910832aa16c616690508ce7