### PR TITLE
fix: return 500 on diagnose failure

### DIFF
--- a/fastify/index.js
+++ b/fastify/index.js
@@ -58,15 +58,17 @@ app.post('/v1/ai/diagnose', async function (request, reply) {
   try {
     await saveToS3(filename, buffer);
     await logToDb(filename);
+    return {
+      crop: 'apple',
+      disease: 'powdery mildew',
+      confidence: 0.87,
+    };
   } catch (err) {
     app.log.error('S3/DB error', err);
+    return reply
+      .code(500)
+      .send({ code: 'SERVICE_UNAVAILABLE', message: 'Failed to process image' });
   }
-
-  return {
-    crop: 'apple',
-    disease: 'powdery mildew',
-    confidence: 0.87,
-  };
 });
 
 app.get('/v1/photos/history', async function (request) {

--- a/tests/fastify_diagnose_error.test.js
+++ b/tests/fastify_diagnose_error.test.js
@@ -1,0 +1,22 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const { S3Client } = require('@aws-sdk/client-s3');
+const { app, pool } = require('../fastify');
+
+test('diagnose returns 500 on S3 error', async (t) => {
+  const mockedSend = mock.method(S3Client.prototype, 'send', async () => {
+    throw new Error('S3 fail');
+  });
+  t.after(() => mockedSend.mock.restore());
+  pool.query = async () => ({ rows: [] });
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v1/ai/diagnose',
+    headers: { 'content-type': 'application/json' },
+    payload: { image_base64: Buffer.from('x').toString('base64') },
+  });
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.json().code, 'SERVICE_UNAVAILABLE');
+});


### PR DESCRIPTION
## Summary
- return 500 when S3/DB upload fails in fastify /v1/ai/diagnose
- test error path for diagnose endpoint

## Testing
- `npm test --prefix bot`
- `node --test tests/fastify_*.test.js`
- `ruff check app tests`
- `pytest`
- `alembic upgrade head`
- `npx spectral lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68932ac683e4832a87034aa1434b59cd