### PR TITLE
[fix] handle cancelAutopay session errors

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -533,6 +533,23 @@ test('cancelAutopay handles unauthorized', { concurrency: false }, async () => {
   assert.equal(replies[0], tr('error_UNAUTHORIZED'));
 });
 
+test('cancelAutopay handles session error', { concurrency: false }, async () => {
+  const replies = [];
+  const ctx = { from: { id: 7 }, reply: async (m) => replies.push(m) };
+  const calls = [];
+  await withMockFetch(
+    {
+      'http://localhost:8000/v1/auth/token': { ok: false, status: 500 },
+    },
+    async () => {
+      await cancelAutopay(ctx);
+    },
+    calls,
+  );
+  assert.equal(replies[0], tr('autopay_cancel_error'));
+  assert.equal(calls.some((c) => c.url.endsWith('/autopay/cancel')), false);
+});
+
 test('paywall disabled does not reply', { concurrency: false }, async () => {
   process.env.PAYWALL_ENABLED = 'false';
   const replies = [];

--- a/bot/payments.js
+++ b/bot/payments.js
@@ -116,6 +116,9 @@ async function cancelAutopay(ctx) {
         'X-User-ID': ctx.from?.id,
       },
     });
+    if (!sessionResp.ok) {
+      return ctx.reply(msg('autopay_cancel_error'));
+    }
     const { jwt, csrf } = await sessionResp.json();
 
     const resp = await fetch(`${API_BASE}/v1/payments/sbp/autopay/cancel`, {


### PR DESCRIPTION
## Summary
- guard cancelAutopay against failed auth token requests
- cover session error scenario with unit test

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_68932f3a7a38832aacba2ee7d157263d