### PR TITLE
refactor: async protocol query wrapper

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -25,7 +25,7 @@ from app.metrics import (
 )
 from app.models import Event, Photo, ErrorCode
 from app.services.gpt import call_gpt_vision
-from app.services.protocols import find_protocol
+from app.services.protocols import async_find_protocol
 from app.services.storage import get_public_url, upload_photo
 from app.services.roi import calculate_roi
 
@@ -284,7 +284,7 @@ async def diagnose(
         queue_size_pending.inc()
         return JSONResponse(status_code=202, content={"id": photo_id, "status": "pending"})
 
-    proto = await asyncio.to_thread(find_protocol, "main", crop, disease)
+    proto = await async_find_protocol("main", crop, disease)
     if proto:
         proto_resp = ProtocolResponse(
             id=proto.id,
@@ -459,8 +459,8 @@ async def photo_status(photo_id: int, user_id: int = Depends(rate_limit)):
         and photo_data["crop"]
         and photo_data["disease"]
     ):
-        p = await asyncio.to_thread(
-            find_protocol, "main", photo_data["crop"], photo_data["disease"]
+        p = await async_find_protocol(
+            "main", photo_data["crop"], photo_data["disease"]
         )
         if p:
             proto = ProtocolResponse(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,7 +140,11 @@ def test_diagnose_multipart_uses_process(monkeypatch, client):
         return "k", "wheat", "rust", 0.5, 2.1
 
     monkeypatch.setattr("app.controllers.photos._process_image", fake_process)
-    monkeypatch.setattr("app.controllers.photos.find_protocol", lambda *_, **__: None)
+
+    async def _fake_proto(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.controllers.photos.async_find_protocol", _fake_proto)
     resp = client.post(
         "/v1/ai/diagnose",
         headers=HEADERS,
@@ -162,7 +166,11 @@ def test_diagnose_base64_uses_process(monkeypatch, client):
         return "k", "corn", "blight", 0.7, 3.3
 
     monkeypatch.setattr("app.controllers.photos._process_image", fake_process)
-    monkeypatch.setattr("app.controllers.photos.find_protocol", lambda *_, **__: None)
+
+    async def _fake_proto(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.controllers.photos.async_find_protocol", _fake_proto)
     encoded = base64.b64encode(b"xyz").decode()
     resp = client.post(
         "/v1/ai/diagnose",


### PR DESCRIPTION
## Summary
- use context-managed DB sessions in protocol lookup
- add async protocol lookup wrapper and call from controllers
- adjust tests for async protocol lookup

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689335541a44832abbdb97c24d2aef2c