### PR TITLE
test: check unauthorized autopay cancel message

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -560,7 +560,7 @@ test('cancelAutopay handles unauthorized', { concurrency: false }, async () => {
       await cancelAutopay(ctx);
     },
   );
-  assert.equal(replies[0], tr('error_UNAUTHORIZED'));
+  assert.equal(replies[0], msg('error_UNAUTHORIZED'));
 });
 
 test('cancelAutopay handles session error', { concurrency: false }, async () => {


### PR DESCRIPTION
## Summary
- expect `msg('error_UNAUTHORIZED')` when autopay cancellation endpoint replies with 401

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_689336dc7e40832ab652e98df0eb7811