### PR TITLE
[fix] Remove stray marker from bot handlers test

### DIFF
--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -6,9 +6,6 @@ process.env.FREE_PHOTO_LIMIT = '5';
 
 process.env.API_BASE_URL = 'http://localhost:8000';
 
-=======
-
-
 const API_BASE = process.env.API_BASE_URL;
 const PAYMENTS_BASE = `${API_BASE}/v1/payments`;
 const {


### PR DESCRIPTION
## Summary
- clean leftover merge marker in handlers unit test

## Testing
- `npm test --prefix bot`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933aa470e0832aaa4c455736a93863