### PR TITLE
fix: set pytest asyncio loop scope

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     smoke: smoke test suite
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
## Summary
- set asyncio fixture loop scope to function

## Testing
- `ruff check app tests`
- `pytest` *(fails: SyntaxError in bot/handlers.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68933a733c3c832a9b118ca41d820336