### PR TITLE
fix: remove broad exception in delete_user

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -87,8 +87,6 @@ async def delete_user(
             code=ErrorCode.BAD_REQUEST, message="Invalid JSON"
         )
         raise HTTPException(status_code=400, detail=err_resp.model_dump()) from err
-    except Exception:  # noqa: BLE001
-        raise
 
     user_id = payload.get("user_id")
     if user_id is None:


### PR DESCRIPTION
## Summary
- handle JSON parsing errors in delete_user without broad exception

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689354ecab50832a941ac006cc6c1119