### PR TITLE
fix: log S3 client creation failures

### DIFF
--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -60,6 +60,13 @@ async def _make_client() -> AioBaseClient:
     )
     try:
         client = await client_ctx.__aenter__()
+    except (BotoCoreError, ClientError) as exc:
+        try:
+            await client_ctx.__aexit__(None, None, None)
+        except Exception:  # pragma: no cover - best effort cleanup
+            logger.exception("Failed to close S3 client after failed entry")
+        logger.exception("Failed to create S3 client: %s", exc)
+        raise
     except Exception:
         try:
             await client_ctx.__aexit__(None, None, None)


### PR DESCRIPTION
## Summary
- log and rethrow S3 client creation errors
- test client creation failure logging

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935ccdbe88832aab2fa0dd090e405c