### PR TITLE
fix: update httpx proxy parameter

### DIFF
--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -30,7 +30,7 @@ def _get_client() -> OpenAI:
         if https_proxy:
             proxies["https://"] = https_proxy
 
-        _http_client = httpx.Client(proxies=proxies) if proxies else None
+        _http_client = httpx.Client(proxy=proxies) if proxies else None
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY environment variable is not set")


### PR DESCRIPTION
## Summary
- replace deprecated `proxies` argument with `proxy` in GPT service

## Testing
- `ruff check app tests`
- `pytest`
- `pytest tests/test_gpt.py::test_get_client_requires_api_key tests/test_gpt.py::test_client_lazy_init -W error`


------
https://chatgpt.com/codex/tasks/task_e_689375e5bb60832aad56e4daa537477c