### PR TITLE
refactor: set CSRF cookie on client in SBP tests

### DIFF
--- a/tests/test_sbp.py
+++ b/tests/test_sbp.py
@@ -205,10 +205,10 @@ def test_autopay_cancel_success(client):
         "Authorization": f"Bearer {JWT_USER1}",
         "X-CSRF-Token": CSRF_TOKEN,
     }
+    client.cookies.set("csrf_token", CSRF_TOKEN)
     resp = client.post(
         "/v1/payments/sbp/autopay/cancel",
         headers=headers,
-        cookies={"csrf_token": CSRF_TOKEN},
         json={"user_id": 1},
     )
     assert resp.status_code == 204
@@ -225,10 +225,10 @@ def test_autopay_cancel_user_mismatch(client):
         "Authorization": f"Bearer {JWT_USER2}",
         "X-CSRF-Token": CSRF_TOKEN,
     }
+    client.cookies.set("csrf_token", CSRF_TOKEN)
     resp = client.post(
         "/v1/payments/sbp/autopay/cancel",
         headers=headers,
-        cookies={"csrf_token": CSRF_TOKEN},
         json={"user_id": 1},
     )
     assert resp.status_code == 401
@@ -244,10 +244,10 @@ def test_autopay_cancel_csrf_fail(client):
         "Authorization": f"Bearer {JWT_USER1}",
         "X-CSRF-Token": "bad",  # mismatch token
     }
+    client.cookies.set("csrf_token", CSRF_TOKEN)
     resp = client.post(
         "/v1/payments/sbp/autopay/cancel",
         headers=headers,
-        cookies={"csrf_token": CSRF_TOKEN},
         json={"user_id": 1},
     )
     assert resp.status_code == 403
@@ -260,10 +260,10 @@ def test_autopay_cancel_jwt_fail(client):
         "Authorization": f"Bearer {JWT_USER2}",  # wrong user in token
         "X-CSRF-Token": CSRF_TOKEN,
     }
+    client.cookies.set("csrf_token", CSRF_TOKEN)
     resp = client.post(
         "/v1/payments/sbp/autopay/cancel",
         headers=headers,
-        cookies={"csrf_token": CSRF_TOKEN},
         json={"user_id": 1},
     )
     assert resp.status_code == 401
@@ -284,10 +284,10 @@ def test_autopay_cancel_jwt_expired(client):
         "Authorization": f"Bearer {expired}",
         "X-CSRF-Token": CSRF_TOKEN,
     }
+    client.cookies.set("csrf_token", CSRF_TOKEN)
     resp = client.post(
         "/v1/payments/sbp/autopay/cancel",
         headers=headers,
-        cookies={"csrf_token": CSRF_TOKEN},
         json={"user_id": 1},
     )
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- avoid per-request cookie deprecation warnings in SBP cancel tests by setting cookies on the TestClient instance

## Testing
- `ruff check tests/test_sbp.py`
- `python -m pytest tests/test_sbp.py`

------
https://chatgpt.com/codex/tasks/task_e_68937a9739e4832ab1d2c569f25029f9