### PR TITLE
fix: handle empty GPT output

### DIFF
--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -90,7 +90,7 @@ def call_gpt_vision(key: str) -> dict:
         crop = data["crop"]
         disease = data["disease"]
         confidence = float(data["confidence"])
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError, IndexError) as exc:
         raise ValueError("Malformed GPT response") from exc
 
     return {"crop": crop, "disease": disease, "confidence": confidence}

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -81,3 +81,17 @@ def test_client_lazy_init(monkeypatch):
     gpt.call_gpt_vision("key")
     assert calls == 1
 
+
+def test_call_gpt_vision_empty_output(monkeypatch):
+    class _FakeResponses:
+        def create(self, **kwargs):  # type: ignore[override]
+            return SimpleNamespace(output=[])
+
+    monkeypatch.setattr(
+        gpt, "_get_client", lambda: SimpleNamespace(responses=_FakeResponses())
+    )
+    monkeypatch.setattr(gpt, "get_public_url", lambda key: "https://example.com/x.jpg")
+
+    with pytest.raises(ValueError):
+        gpt.call_gpt_vision("photo.jpg")
+


### PR DESCRIPTION
## Summary
- handle missing entries in GPT response
- test for empty GPT response

## Testing
- `ruff check app tests`
- `npx spectral lint openapi/openapi.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68938b3717d0832aa2544044ae36283a