### PR TITLE
fix: reset GPT client after close

### DIFF
--- a/app/services/gpt.py
+++ b/app/services/gpt.py
@@ -38,8 +38,11 @@ def _get_client() -> OpenAI:
 
 
 def _close_client() -> None:
+    global _client, _http_client
     if _http_client is not None:
         _http_client.close()
+    _http_client = None
+    _client = None
 
 
 atexit.register(_close_client)

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -95,3 +95,24 @@ def test_call_gpt_vision_empty_output(monkeypatch):
     with pytest.raises(ValueError):
         gpt.call_gpt_vision("photo.jpg")
 
+
+def test_get_client_recreates_after_close(monkeypatch):
+    calls = 0
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            nonlocal calls
+            calls += 1
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(gpt, "OpenAI", _FakeOpenAI)
+    monkeypatch.setattr(gpt, "_client", None)
+    monkeypatch.setattr(gpt, "_http_client", None)
+
+    first = gpt._get_client()
+    gpt._close_client()
+    second = gpt._get_client()
+
+    assert calls == 2
+    assert first is not second
+


### PR DESCRIPTION
## Summary
- reset both GPT client and HTTP client to None when closing so fresh instances are recreated
- test that `_get_client` recreates a new client after `_close_client`

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68938e49b524832a812bdd358f9941f4