### PR TITLE
fix: return error payloads from ask_expert endpoint

### DIFF
--- a/app/controllers/experts.py
+++ b/app/controllers/experts.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ValidationError
 
@@ -27,19 +27,19 @@ async def ask_expert(
 
     try:
         payload = await request.json()
-    except json.JSONDecodeError as exc:
+    except json.JSONDecodeError:
         err = ErrorResponse(
             code=ErrorCode.BAD_REQUEST, message="Invalid JSON payload"
         )
-        raise HTTPException(status_code=400, detail=err.model_dump()) from exc
+        return JSONResponse(status_code=400, content=err.model_dump())
 
     try:
         AskExpertRequest.model_validate(payload)
-    except ValidationError as exc:
+    except ValidationError:
         err = ErrorResponse(
             code=ErrorCode.BAD_REQUEST, message="Invalid request body"
         )
-        raise HTTPException(status_code=400, detail=err.model_dump()) from exc
+        return JSONResponse(status_code=400, content=err.model_dump())
 
     def _db_call() -> None:
         with db_module.SessionLocal() as db:

--- a/tests/test_expert.py
+++ b/tests/test_expert.py
@@ -42,6 +42,11 @@ def test_ask_expert_empty_question(client):
         json={"question": ""},
     )
     assert resp.status_code == 400
+    assert resp.json() == {
+        "code": "BAD_REQUEST",
+        "message": "Invalid request body",
+    }
+    assert "detail" not in resp.json()
 
 
 def test_ask_expert_too_long_question(client):
@@ -51,3 +56,22 @@ def test_ask_expert_too_long_question(client):
         json={"question": "a" * 501},
     )
     assert resp.status_code == 400
+    assert resp.json() == {
+        "code": "BAD_REQUEST",
+        "message": "Invalid request body",
+    }
+    assert "detail" not in resp.json()
+
+
+def test_ask_expert_invalid_json(client):
+    resp = client.post(
+        "/v1/ask_expert",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        content="not json",
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {
+        "code": "BAD_REQUEST",
+        "message": "Invalid JSON payload",
+    }
+    assert "detail" not in resp.json()


### PR DESCRIPTION
## Summary
- return `ErrorResponse` JSON instead of HTTPException for invalid payloads
- test `ask_expert` returns flat error bodies without `detail`

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893919fbbcc832ab1cea665a189cbf8