### PR TITLE
fix(bot): read API error code from 'code' field

### DIFF
--- a/bot/diagnosis.js
+++ b/bot/diagnosis.js
@@ -140,7 +140,7 @@ async function photoHandler(pool, ctx) {
       let errCode;
       try {
         const errData = await apiResp.json();
-        errCode = errData?.error_code;
+        errCode = errData?.code;
       } catch (err) {
         console.error('Failed to parse API error response', err);
       }

--- a/bot/handlers.test.js
+++ b/bot/handlers.test.js
@@ -119,7 +119,7 @@ test('photoHandler responds with error_code message', { concurrency: false }, as
   };
   await withMockFetch({
     'http://file': { body: Readable.from(Buffer.from('x')) },
-    default: { ok: false, status: 400, json: async () => ({ error_code: 'NO_LEAF' }) },
+    default: { ok: false, status: 400, json: async () => ({ code: 'NO_LEAF' }) },
   }, async () => {
     await photoHandler(pool, ctx);
   });


### PR DESCRIPTION
## Summary
- handle API error responses using the new `code` field in `bot/diagnosis`
- adjust unit test to mock the new error field

## Testing
- `npm test --prefix bot`


------
https://chatgpt.com/codex/tasks/task_e_6893a65394f0832a80eb9c34225c886a