### PR TITLE
fix: generate unique S3 filenames with UUID

### DIFF
--- a/fastify/index.js
+++ b/fastify/index.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const crypto = require('crypto');
 const Fastify = require('fastify');
 const fastifyMultipart = require('@fastify/multipart');
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
@@ -44,7 +45,8 @@ app.post('/v1/ai/diagnose', async function (request, reply) {
 
   if (request.isMultipart()) {
     const data = await request.file();
-    filename = Date.now() + '-' + (data.filename || 'upload');
+    filename =
+      Date.now() + '-' + crypto.randomUUID() + '-' + (data.filename || 'upload');
     buffer = await data.toBuffer();
   } else {
     const body = request.body;
@@ -52,7 +54,7 @@ app.post('/v1/ai/diagnose', async function (request, reply) {
       return reply.code(400).send({ code: 'BAD_REQUEST', message: 'No image' });
     }
     buffer = Buffer.from(body.image_base64, 'base64');
-    filename = Date.now() + '-base64.jpg';
+    filename = Date.now() + '-' + crypto.randomUUID() + '-base64.jpg';
   }
 
   try {

--- a/tests/fastify_unique_key.test.js
+++ b/tests/fastify_unique_key.test.js
@@ -1,0 +1,36 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const { S3Client } = require('@aws-sdk/client-s3');
+const crypto = require('crypto');
+const { app, pool } = require('../fastify');
+
+test('diagnose uses unique filename', async (t) => {
+  const keys = [];
+  const mockedDate = mock.method(Date, 'now', () => 1700000000000);
+  let uuidCount = 0;
+  const mockedUUID = mock.method(crypto, 'randomUUID', () => String(uuidCount++));
+  const mockedSend = mock.method(S3Client.prototype, 'send', async (cmd) => {
+    keys.push(cmd.input.Key);
+    return {};
+  });
+  t.after(() => {
+    mockedDate.mock.restore();
+    mockedUUID.mock.restore();
+    mockedSend.mock.restore();
+  });
+  pool.query = async () => ({ rows: [] });
+  const payload = { image_base64: Buffer.from('x').toString('base64') };
+  await app.inject({
+    method: 'POST',
+    url: '/v1/ai/diagnose',
+    headers: { 'content-type': 'application/json' },
+    payload,
+  });
+  await app.inject({
+    method: 'POST',
+    url: '/v1/ai/diagnose',
+    headers: { 'content-type': 'application/json' },
+    payload,
+  });
+  assert.deepEqual(keys, ['1700000000000-0-base64.jpg', '1700000000000-1-base64.jpg']);
+});


### PR DESCRIPTION
Type: [fix]

## Summary
- use `crypto.randomUUID()` with timestamp when naming uploaded photos
- add unit test to ensure unique S3 keys

## Testing
- `ruff check app tests`
- `pytest`
- `node --test tests/fastify_*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893aa7b07d4832a88e251eacf336d73