### PR TITLE
fix: configure protocol catalog URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 from pydantic import ConfigDict, Field
 from pydantic_settings import BaseSettings
 
+DEFAULT_CATALOG_URL = (
+    "https://mcx.gov.ru/ministry/departments/"
+    "departament-rastenievodstva-mekhanizatsii-khimizatsii-"
+    "zashchity-rasteniy/industry-information/"
+    "info-gosudarstvennaya-usluga-po-gosudarstvennoy-registratsii-"
+    "pestitsidov-i-agrokhimikatov/"
+)
+
 
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
@@ -39,6 +47,14 @@ class Settings(BaseSettings):
     s3_access_key: str | None = None
     s3_secret_key: str | None = None
     s3_public_url: str | None = None
+
+    catalog_main_url: str = Field(DEFAULT_CATALOG_URL, alias="CATALOG_MAIN_URL")
+    catalog_pesticide_url: str = Field(
+        DEFAULT_CATALOG_URL, alias="CATALOG_PESTICIDE_URL"
+    )
+    catalog_agrochem_url: str = Field(
+        DEFAULT_CATALOG_URL, alias="CATALOG_AGROCHEM_URL"
+    )
 
     model_config = ConfigDict(
         extra="ignore",

--- a/app/services/protocol_importer.py
+++ b/app/services/protocol_importer.py
@@ -40,13 +40,12 @@ logger = logging.getLogger(__name__)
 
 FIELDNAMES = ["crop", "disease", "product", "dosage_value", "dosage_unit", "phi"]
 
-# Mapping of catalog categories to pages that list available archives.  The
-# values here are placeholders; in production they should point to real pages
-# on the Ministry of Agriculture website.
+# Mapping of catalog categories to pages that list available archives.  URLs
+# are configurable via environment variables, see ``Settings``.
 CATALOG_PAGES = {
-    "main": "https://example.com/",
-    "pesticide": "https://example.com/pesticide/",
-    "agrochem": "https://example.com/agrochem/",
+    "main": cfg.catalog_main_url,
+    "pesticide": cfg.catalog_pesticide_url,
+    "agrochem": cfg.catalog_agrochem_url,
 }
 
 


### PR DESCRIPTION
## Summary
- load protocol catalog URLs from settings with default to Ministry of Agriculture page
- import protocols using configurable catalog pages instead of placeholders

## Testing
- `ruff check app tests`
- `pytest`
- `alembic upgrade head`
- `python -m app.services.protocol_importer --category main` *(fails: 503 Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_6893b2b00e84832abc8b1a39e6a54c93