### PR TITLE
feat: allow custom SSL for catalog importer

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -97,3 +97,11 @@ RETRY_LIMIT=3
 PRIVACY_URL=
 BETA_EXPERT_CHAT=false
 FEEDBACK_URL=https://example.com/feedback
+
+# =========================
+# 📚 Catalog Import SSL
+# =========================
+# Verify TLS certificates when downloading protocol archives
+CATALOG_SSL_VERIFY=true
+# Path to a custom CA bundle file
+CATALOG_CA_BUNDLE=

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ python -m app.services.protocol_importer <zip_url> --category main
 В продакшене утилита запускается ежемесячным CRON‑джобом для актуализации
 протоколов.
 
+Если сервер каталога использует самоподписанный сертификат, задайте путь к
+файлу доверенного сертификата через переменную окружения `CATALOG_CA_BUNDLE`.
+Чтобы полностью отключить проверку TLS, установите `CATALOG_SSL_VERIFY=false`.
+
 ### Ежемесячные задачи CRON
 
 - `python -m app.services.protocol_importer` — обновляет таблицы `catalogs` и

--- a/app/config.py
+++ b/app/config.py
@@ -55,6 +55,8 @@ class Settings(BaseSettings):
     catalog_agrochem_url: str = Field(
         DEFAULT_CATALOG_URL, alias="CATALOG_AGROCHEM_URL"
     )
+    catalog_ssl_verify: bool = Field(True, alias="CATALOG_SSL_VERIFY")
+    catalog_ca_bundle: str | None = Field(None, alias="CATALOG_CA_BUNDLE")
 
     model_config = ConfigDict(
         extra="ignore",

--- a/app/services/protocol_importer.py
+++ b/app/services/protocol_importer.py
@@ -82,7 +82,12 @@ def download_zip(url: str, dest: Path) -> Path:
     """Download ``url`` into ``dest`` and return the resulting path."""
 
     try:
-        with requests.get(url, timeout=30, stream=True) as response:
+        with requests.get(
+            url,
+            timeout=30,
+            stream=True,
+            verify=cfg.catalog_ca_bundle or cfg.catalog_ssl_verify,
+        ) as response:
             response.raise_for_status()
             total = int(response.headers.get("Content-Length", 0))
             downloaded = 0
@@ -196,7 +201,11 @@ def run_import(category: str, force: bool = False) -> None:
     if not page_url:
         raise ValueError(f"Unknown catalog category: {category}")
 
-    response = requests.get(page_url, timeout=30)
+    response = requests.get(
+        page_url,
+        timeout=30,
+        verify=cfg.catalog_ca_bundle or cfg.catalog_ssl_verify,
+    )
     response.raise_for_status()
     zip_url = find_latest_zip(response.text, page_url)
     logger.info("Latest archive URL: %s", zip_url)

--- a/tests/test_protocol_importer_cli.py
+++ b/tests/test_protocol_importer_cli.py
@@ -20,7 +20,7 @@ def test_run_import_inserts_data(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         protocol_importer.requests,
         "get",
-        lambda url, timeout=30: DummyResponse(html),
+        lambda url, timeout=30, **kwargs: DummyResponse(html),
     )
 
     def fake_download_zip(url: str, dest: Path) -> Path:


### PR DESCRIPTION
## Summary
- add `CATALOG_SSL_VERIFY` and `CATALOG_CA_BUNDLE` settings
- honor CA bundle or disable TLS verification when fetching protocol archives
- document new environment variables

## Testing
- `ruff check app tests`
- `pytest -q`
- `npx --yes spectral lint -r .spectral.yaml openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `alembic -x echo=true upgrade head`

------
https://chatgpt.com/codex/tasks/task_e_68942871520c832aa274e4425e59251c