### PR TITLE
[fix] handle SSL errors in protocol importer

### DIFF
--- a/app/services/protocol_importer.py
+++ b/app/services/protocol_importer.py
@@ -208,12 +208,12 @@ def run_import(category: str, force: bool = False) -> None:
             # Allow custom CA bundle or skipping verification if required
             verify=cfg.catalog_ca_bundle or cfg.catalog_ssl_verify,
         )
-        response.raise_for_status()
     except requests.exceptions.SSLError:
         logger.error(
             "SSL error fetching catalog page. Set CATALOG_CA_BUNDLE or CATALOG_SSL_VERIFY."
         )
         return
+    response.raise_for_status()
     zip_url = find_latest_zip(response.text, page_url)
     logger.info("Latest archive URL: %s", zip_url)
 

--- a/tests/test_protocol_importer_cli.py
+++ b/tests/test_protocol_importer_cli.py
@@ -54,7 +54,8 @@ def test_run_import_logs_ssl_error(monkeypatch, caplog, tmp_path: Path) -> None:
 
     with tmp_db(tmp_path):
         with caplog.at_level("ERROR"):
-            protocol_importer.run_import("main")
+            result = protocol_importer.run_import("main")
 
+    assert result is None
     assert "CATALOG_CA_BUNDLE" in caplog.text
     assert "CATALOG_SSL_VERIFY" in caplog.text


### PR DESCRIPTION
## Summary
- handle SSL certificate errors gracefully when fetching protocol page
- test importer behavior on SSL failures

## Testing
- `ruff check app tests`
- `pytest`
- `alembic upgrade head`
- `npx -y @stoplight/spectral-cli lint openapi/openapi.yaml`
- `npx -y openapi-diff openapi/openapi.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689433e44504832a864461fccf39abac