### PR TITLE
fix: handle schedule errors in retry worker

### DIFF
--- a/worker/retry_diagnosis.js
+++ b/worker/retry_diagnosis.js
@@ -33,7 +33,7 @@ async function schedule() {
   );
 }
 
-schedule();
+schedule().catch(console.error);
 
 new Worker(
   queueName,


### PR DESCRIPTION
## Summary
- handle retry worker schedule errors to avoid unhandled rejections

## Testing
- `npm test`
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689434ccf46c832ab884a20ab6c5eeea