### PR TITLE
fix: narrow bot volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       context: ./bot
       dockerfile: Dockerfile
     volumes:
-      - .:/usr/src/app
+      - ./bot:/usr/src/app
     env_file: .env
     environment:
       DATABASE_URL: ${DATABASE_URL}


### PR DESCRIPTION
## Summary
- mount only bot directory in docker-compose bot service

## Testing
- `ruff check app tests`
- `pytest`
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `docker compose up --build bot` *(fails: docker engine not running)*

------
https://chatgpt.com/codex/tasks/task_e_68b134a89530832a9ab8f0a5695bdd60