### PR TITLE
[feature] Add emojis to bot command menu

### DIFF
--- a/app/services/protocol_importer.py
+++ b/app/services/protocol_importer.py
@@ -811,8 +811,10 @@ def run_import(category: str, force: bool = False) -> None:
         zip_path = download_zip(zip_url, tmpdir / "archive.zip")
 
         # Папка для отладочных дампов (только текст, и только первые страницы)
-        dbg_root = Path("debug_protocols"); dbg_root.mkdir(exist_ok=True)
-        ts_dir = dbg_root / datetime.now().strftime("%Y%m%d-%H%M%S"); ts_dir.mkdir(exist_ok=True)
+        dbg_root = Path("debug_protocols")
+        dbg_root.mkdir(exist_ok=True)
+        ts_dir = dbg_root / datetime.now().strftime("%Y%m%d-%H%M%S")
+        ts_dir.mkdir(exist_ok=True)
 
         all_rows: List[dict] = []
         first_pdf_saved = False

--- a/bot/index.js
+++ b/bot/index.js
@@ -31,16 +31,16 @@ const bot = new Telegraf(token);
 async function init() {
   try {
     await bot.telegram.setMyCommands([
-      { command: 'start', description: 'Начать работу' },
-      { command: 'help', description: 'Помощь' },
-      { command: 'history', description: 'История запросов' },
-      { command: 'retry', description: 'Повторить диагностику' },
-      { command: 'subscribe', description: 'Купить PRO' },
-      { command: 'autopay_enable', description: 'Включить автоплатёж' },
-      { command: 'cancel_autopay', description: 'Отключить автоплатёж' },
-      { command: 'ask_expert', description: 'Задать вопрос эксперту' },
-      { command: 'reminder', description: 'Управление напоминаниями' },
-      { command: 'feedback', description: 'Оставить отзыв' },
+      { command: 'start', description: '🌱 Начать работу' },
+      { command: 'help', description: 'ℹ️ Помощь' },
+      { command: 'history', description: '📜 История запросов' },
+      { command: 'retry', description: '🔄 Повторить диагностику' },
+      { command: 'subscribe', description: '💳 Купить PRO' },
+      { command: 'autopay_enable', description: '▶️ Включить автоплатёж' },
+      { command: 'cancel_autopay', description: '⛔ Отключить автоплатёж' },
+      { command: 'ask_expert', description: '🧑‍🌾 Задать вопрос эксперту' },
+      { command: 'reminder', description: '⏰ Управление напоминаниями' },
+      { command: 'feedback', description: '💬 Оставить отзыв' },
     ]);
 
     bot.start(async (ctx) => {


### PR DESCRIPTION
## Summary
- add emoji icons to bot command menu
- split debug folder path creation onto separate lines for lint compliance

## Testing
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `ruff check app tests`
- `pytest` *(fails: ImportError: cannot import name 'find_latest_zip')*

------
https://chatgpt.com/codex/tasks/task_e_68b1559e4e60832a90594ad443c4873b