### PR TITLE
fix: delete photo usage on user removal

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from app import db as db_module
 from app.config import Settings
 from app.dependencies import ErrorResponse, compute_signature, rate_limit
-from app.models import Event, Payment, Photo, User, ErrorCode
+from app.models import Event, Payment, Photo, PhotoUsage, User, ErrorCode
 
 settings = Settings()
 HMAC_SECRET = settings.hmac_secret
@@ -151,6 +151,7 @@ async def delete_user(
             db.query(Photo).filter_by(user_id=user_id).delete()
             db.query(Payment).filter_by(user_id=user_id).delete()
             db.query(Event).filter_by(user_id=user_id).delete()
+            db.query(PhotoUsage).filter_by(user_id=user_id).delete()
             db.query(User).filter_by(id=user_id).delete()
             db.commit()
 

--- a/tests/test_users_dsr.py
+++ b/tests/test_users_dsr.py
@@ -5,7 +5,7 @@ import zipfile
 from app.config import Settings
 from app.db import SessionLocal
 from app.dependencies import compute_signature
-from app.models import Event, Payment, Photo, User
+from app.models import Event, Payment, Photo, PhotoUsage, User
 
 HEADERS = {
     "X-API-Key": "test-api-key",
@@ -21,6 +21,7 @@ def _prepare_db():
         db.query(Photo).filter_by(user_id=1).delete()
         db.query(Payment).filter_by(user_id=1).delete()
         db.query(Event).filter_by(user_id=1).delete()
+        db.query(PhotoUsage).filter_by(user_id=1).delete()
         db.query(User).filter_by(id=1).delete()
         db.add(User(id=1, tg_id=1))
         db.add(Photo(user_id=1, file_id="f1"))
@@ -34,6 +35,7 @@ def _prepare_db():
             )
         )
         db.add(Event(user_id=1, event="login"))
+        db.add(PhotoUsage(user_id=1, month="2024-01", used=1))
         db.commit()
 
 
@@ -104,6 +106,7 @@ def test_delete_user_cascade(client):
         assert db.query(Photo).filter_by(user_id=1).count() == 0
         assert db.query(Payment).filter_by(user_id=1).count() == 0
         assert db.query(Event).filter_by(user_id=1).count() == 0
+        assert db.query(PhotoUsage).filter_by(user_id=1).count() == 0
 
 
 def test_delete_user_bad_signature(client):


### PR DESCRIPTION
## Summary
- include PhotoUsage when deleting user data
- cover photo_usage cascade removal in DSR test

## Testing
- `ruff check app tests`
- `pytest` *(fails: ImportError: cannot import name 'find_latest_zip' from 'app.services.protocol_importer')*

------
https://chatgpt.com/codex/tasks/task_e_68b158eb2368832ab615820dd00fe0b4