### PR TITLE
[fix] mount locales volume for bot service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./bot:/usr/src/app
+      - ./locales:/usr/src/locales
     env_file: .env
     environment:
       DATABASE_URL: ${DATABASE_URL}


### PR DESCRIPTION
## Summary
- mount `locales` directory into bot service so `../locales/ru.json` resolves

## Testing
- `ruff check app tests`
- `pytest` *(fails: ImportError: cannot import name 'find_latest_zip')*
- `node bot/handlers.test.js`
- `docker compose up -d --build bot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b159367e30832aad20898ca7279423