### PR TITLE
fix: load database password from env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,7 +25,7 @@ API_VER=v1
 # 🗄️  Database/PostgreSQL
 # ========================
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_PASSWORD=
 POSTGRES_DB=your_db
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432

--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ agronom-bot/
 
 Перед началом убедитесь, что у вас установлен Node.js версии 18 или выше.
 
-1. Скопируйте файл шаблона переменных окружения командой `cp .env.template .env` и укажите параметры подключения к БД и S3. Минимально нужны:
+1. Скопируйте файл шаблона переменных окружения командой `cp .env.template .env` и укажите параметры подключения к БД и S3. Минимально нужны (обязательно задайте `POSTGRES_PASSWORD` в `.env`):
 
    ```env
    POSTGRES_USER=postgres
-   POSTGRES_PASSWORD=postgres
+   POSTGRES_PASSWORD=your-postgres-password
    POSTGRES_DB=agronom
    POSTGRES_HOST=localhost
    POSTGRES_PORT=5432
-   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
-   BOT_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agronom
+   DATABASE_URL=postgresql://postgres:your-postgres-password@localhost:5432/agronom
+   BOT_DATABASE_URL=postgresql://postgres:your-postgres-password@localhost:5432/agronom
    API_BASE_URL=http://localhost:8000
 
    S3_BUCKET=agronom

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - LANG=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
       - POSTGRES_USER=agronom_user
-      - POSTGRES_PASSWORD=GbygkhYbd67
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=agronom_bot
 
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- remove hard-coded Postgres password from docker-compose
- add POSTGRES_PASSWORD placeholder in .env.template and docs

## Testing
- `ruff check app tests`
- `pytest` *(fails: ImportError cannot import name 'find_latest_zip' from 'app.services.protocol_importer')*
- `alembic upgrade head`
- `npx spectral lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b159490a9c832a98b3e8f5cc36c37b