### PR TITLE
feat: enforce 2MB limit for diagnose uploads

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -230,7 +230,18 @@ async def diagnose(
                 code=ErrorCode.BAD_REQUEST, message="prompt_id must be 'v1'"
             )
             return JSONResponse(status_code=400, content=err.model_dump())
-        contents = await image.read()
+        limit = 2 * 1024 * 1024
+        if getattr(image, "size", None) and image.size > limit:
+            err = ErrorResponse(
+                code=ErrorCode.BAD_REQUEST, message="image too large"
+            )
+            return JSONResponse(status_code=400, content=err.model_dump())
+        contents = await image.read(limit + 1)
+        if len(contents) > limit:
+            err = ErrorResponse(
+                code=ErrorCode.BAD_REQUEST, message="image too large"
+            )
+            return JSONResponse(status_code=400, content=err.model_dump())
     else:
         try:
             json_data = await request.json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -225,6 +225,19 @@ def test_diagnose_large_image(client):
     assert resp.status_code == 400
 
 
+def test_diagnose_large_image_error_payload(client):
+    large = b"0" * (2 * 1024 * 1024 + 1)
+    resp = client.post(
+        "/v1/ai/diagnose",
+        headers=HEADERS,
+        files={"image": ("big.jpg", large, "image/jpeg")},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["code"] == ErrorCode.BAD_REQUEST
+    assert body["message"] == "image too large"
+
+
 def test_diagnose_large_base64(client):
     large_bytes = b"0" * (2 * 1024 * 1024 + 1)
     encoded = base64.b64encode(large_bytes).decode()


### PR DESCRIPTION
## Summary
- avoid reading full image if it's bigger than 2MB
- test oversize upload returns BAD_REQUEST

## Testing
- `ruff check app tests`
- `pytest` *(fails: ImportError: cannot import name 'find_latest_zip')*
- `pytest tests/test_api.py::test_diagnose_large_image_error_payload -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1590a704c832a949adb5934e2fed1