### PR TITLE
feat: track diagnose uploads per user

### DIFF
--- a/tests/fastify_user_history.test.js
+++ b/tests/fastify_user_history.test.js
@@ -1,0 +1,61 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const { S3Client } = require('@aws-sdk/client-s3');
+const { app, pool } = require('../fastify');
+
+test('diagnose logs photo under provided user id', async (t) => {
+  const inserted = [];
+  const rowsByUser = {};
+  pool.query = async (sql, params) => {
+    if (sql.startsWith('INSERT')) {
+      const [userId, key, status] = params;
+      inserted.push({ userId, key });
+      rowsByUser[userId] = [
+        {
+          photo_id: 1,
+          ts: new Date('2024-01-01T00:00:00Z'),
+          crop: 'apple',
+          disease: 'powdery mildew',
+          status,
+          confidence: 0.9,
+          file_id: key,
+        },
+      ];
+      return { rows: [] };
+    }
+    if (sql.startsWith('SELECT')) {
+      const [userId] = params;
+      return { rows: rowsByUser[userId] || [] };
+    }
+    return { rows: [] };
+  };
+
+  const mockedSend = mock.method(S3Client.prototype, 'send', async () => ({}));
+  t.after(() => mockedSend.mock.restore());
+
+  const payload = { image_base64: Buffer.from('x').toString('base64') };
+  await app.inject({
+    method: 'POST',
+    url: '/v1/ai/diagnose',
+    headers: { 'content-type': 'application/json', 'x-user-id': '7' },
+    payload,
+  });
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/v1/photos/history',
+    headers: { 'x-user-id': '7' },
+  });
+
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.equal(body.length, 1);
+  assert.ok(body[0].thumb_url.endsWith(inserted[0].key));
+
+  const other = await app.inject({
+    method: 'GET',
+    url: '/v1/photos/history',
+    headers: { 'x-user-id': '8' },
+  });
+  assert.equal(other.json().length, 0);
+});


### PR DESCRIPTION
## Summary
- pass `x-user-id` header to `logToDb`
- store user ID in database instead of constant
- test that photos history reflects uploading user

## Testing
- `ruff check app tests`
- `pytest` *(fails: cannot import name 'find_latest_zip')*
- `node --test tests/fastify_user_history.test.js` *(fails: Cannot find module 'fastify')*

------
https://chatgpt.com/codex/tasks/task_e_68b167b9cde8832aa53ee2b456ac0c36