### PR TITLE
feat: enforce image upload size limit

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -349,6 +349,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Image too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '402':
           description: Free quota exceeded
           content:


### PR DESCRIPTION
## Summary
- reject uploads larger than 2MB with HTTP 413
- add boundary checks for base64 and multipart images
- document 2MB limit and test oversized/valid uploads

## Testing
- `ruff check app tests`
- `pytest tests/test_api.py`
- `npx spectral lint openapi/openapi.yaml`
- `npx --yes openapi-diff openapi/openapi.yaml openapi/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b167c2ad60832a8ec44e4241c5d5e5