### PR TITLE
[fix] handle nullable confidence in photo history

### DIFF
--- a/app/controllers/photos.py
+++ b/app/controllers/photos.py
@@ -209,7 +209,7 @@ class PhotoHistoryItem(BaseModel):
     crop: str
     disease: str
     status: str
-    confidence: float
+    confidence: float | None = None
     thumb_url: str
 
 
@@ -413,7 +413,7 @@ async def list_photos_history(
                     crop=r.crop or "",
                     disease=r.disease or "",
                     status=r.status,
-                    confidence=float(r.confidence or 0),
+                    confidence=float(r.confidence) if r.confidence is not None else None,
                     thumb_url=get_public_url(r.file_id),
                 )
                 for r in rows

--- a/fastify/index.js
+++ b/fastify/index.js
@@ -107,7 +107,7 @@ app.get('/v1/photos/history', async function (request) {
     crop: r.crop,
     disease: r.disease,
     status: r.status,
-    confidence: parseFloat(r.confidence),
+    confidence: r.confidence === null ? null : parseFloat(r.confidence),
     thumb_url: `${baseUrl}/${r.file_id}`,
   }));
 });

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -161,6 +161,7 @@ components:
         confidence:
           type: number
           format: float
+          nullable: true
           example: 0.92
         thumb_url:
           type: string

--- a/tests/fastify_history.test.js
+++ b/tests/fastify_history.test.js
@@ -34,3 +34,25 @@ test('history treats negative offset as 0', async () => {
   assert.equal(res.statusCode, 200);
   assert.equal(received[2], 0);
 });
+
+test('history maps null confidence to null', async () => {
+  pool.query = async () => {
+    return {
+      rows: [
+        {
+          photo_id: 1,
+          ts: new Date().toISOString(),
+          crop: 'apple',
+          disease: 'scab',
+          status: 'ok',
+          confidence: null,
+          file_id: 'f.jpg',
+        },
+      ],
+    };
+  };
+  const res = await app.inject('/v1/photos/history');
+  assert.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body);
+  assert.equal(body[0].confidence, null);
+});

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -505,6 +505,23 @@ def test_photos_history_forbidden_other_user(client):
     assert resp.status_code == 200
 
 
+def test_photos_history_confidence_nullable(client):
+    from app.db import SessionLocal
+    from app.models import Photo
+
+    with SessionLocal() as session:
+        photo = Photo(user_id=1, file_id="null.jpg", status="ok", confidence=None)
+        session.add(photo)
+        session.commit()
+        pid = photo.id
+
+    resp = client.get("/v1/photos/history", headers=HEADERS)
+    assert resp.status_code == 200
+    items = resp.json()
+    item = next(i for i in items if i["photo_id"] == pid)
+    assert item["confidence"] is None
+
+
 def test_photo_status_pending(client):
     from app.db import SessionLocal
     from app.models import Photo


### PR DESCRIPTION
## Summary
- return null when confidence is missing in photo history rows
- allow nullable confidence in API schema and models
- cover photo history responses with tests

## Testing
- `ruff check app tests`
- `pytest tests/test_api.py::test_photos_history_confidence_nullable -q`
- `node --test tests/fastify_history.test.js` *(fails: Cannot find module 'fastify')*
- `pytest` *(fails: cannot import name 'find_latest_zip')*
- `npx @stoplight/spectral-cli lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_68b167c6a594832ab5737f7bf1acfc2c