### PR TITLE
fix: validate user_id type before deletion

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -191,10 +191,19 @@ async def delete_user(
             ).model_dump(),
         ) from err
 
-    user_id = payload.get("user_id")
-    if user_id is None:
+    raw_user_id = payload.get("user_id")
+    if raw_user_id is None:
         err_resp = ErrorResponse(
-            code=ErrorCode.BAD_REQUEST, message="Missing user_id"
+            code=ErrorCode.BAD_REQUEST, message="Missing user_id",
+        )
+        raise HTTPException(status_code=400, detail=err_resp.model_dump())
+
+    try:
+        user_id = int(raw_user_id)
+    except (TypeError, ValueError):
+        err_resp = ErrorResponse(
+            code=ErrorCode.BAD_REQUEST,
+            message="user_id must be an integer",
         )
         raise HTTPException(status_code=400, detail=err_resp.model_dump())
 

--- a/tests/test_users_dsr.py
+++ b/tests/test_users_dsr.py
@@ -1,6 +1,7 @@
 import io
 import json
 import zipfile
+import pytest
 
 from app.config import Settings
 from app.db import SessionLocal
@@ -166,3 +167,27 @@ def test_delete_user_forbidden(client):
         "/v1/dsr/delete_user", headers=headers, json={"user_id": 1}
     )
     assert resp.status_code == 403
+
+
+
+@pytest.mark.parametrize("user_id", ["oops", ["1"]])
+def test_delete_user_invalid_user_id_type(client, user_id):
+    _prepare_db()
+    sig = compute_signature(HMAC_SECRET, {"user_id": user_id})
+    resp = client.post(
+        "/v1/dsr/delete_user",
+        headers=HEADERS | {"X-Sign": sig},
+        json={"user_id": user_id},
+    )
+    assert resp.status_code == 400
+
+
+def test_delete_user_success_int_id(client):
+    _prepare_db()
+    sig = compute_signature(HMAC_SECRET, {"user_id": 1})
+    resp = client.post(
+        "/v1/dsr/delete_user",
+        headers=HEADERS | {"X-Sign": sig},
+        json={"user_id": 1},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- ensure `/dsr/delete_user` validates `user_id` as an integer and returns 400 on type errors before checking signature
- cover invalid `user_id` types and valid integer deletion with unit tests

## Testing
- `ruff check app tests`
- `pytest` *(fails: ImportError: cannot import name 'find_latest_zip' from 'app.services.protocol_importer')*


------
https://chatgpt.com/codex/tasks/task_e_68b167c912e0832ab041fb45abada64d