### PR TITLE
fix(bot): include locales in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ docker-compose.yml
 node_modules/
 tests/
 docs/
-locales/
 # bot/
 monitoring/
 k8s/

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,6 +1,13 @@
 FROM node:20
 WORKDIR /usr/src/app
-COPY package*.json ./
+
+# Install dependencies using bot package manifests
+COPY bot/package*.json ./
 RUN npm ci
-COPY . .
+
+# Copy bot sources
+COPY bot/ .
+# Include shared localization files
+COPY locales ./locales
+
 ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
## Summary
- include locales when building bot image to avoid missing module errors
- add locales to Docker build context

## Testing
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `docker build -f bot/Dockerfile -t agronom-bot-bot .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `BOT_TOKEN_DEV=foo DATABASE_URL=postgres://user:pass@localhost:5432/db node bot/index.js` *(fails: request to https://api.telegram.org/botfoo/setMyCommands failed, reason: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b173ce4b90832abdf0d14623ea1189