### PR TITLE
fix: ensure migrations run with project root

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -2,15 +2,16 @@
 import os
 import sys
 from pathlib import Path
+
+# Add project root to PYTHONPATH before importing app modules
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from dotenv import load_dotenv
 from alembic import context
 from sqlalchemy import create_engine, pool
 
-# 1. .env
+# Load .env variables
 load_dotenv()
-
-# 2. PYTHONPATH до импорта app
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.models import Base  # noqa: E402
 


### PR DESCRIPTION
## Summary
- ensure Alembic env adds project root to PYTHONPATH before importing modules

## Testing
- `ruff check app tests`
- `pytest` *(fails: ImportError: cannot import name 'find_latest_zip')*
- `npx spectral lint openapi/openapi.yaml`
- `npx openapi-diff openapi/openapi.yaml openapi/openapi.yaml`
- `alembic upgrade head && alembic current`
- `python - <<'PY' from app.models import Base print(Base) PY`


------
https://chatgpt.com/codex/tasks/task_e_68b1b33ef280832a8e488899ae6d242c